### PR TITLE
proto: lint with clang-format

### DIFF
--- a/evmos/x/erc20/types/erc20.pb.go
+++ b/evmos/x/erc20/types/erc20.pb.go
@@ -65,7 +65,8 @@ type TokenPair struct {
 	Denom string `protobuf:"bytes,2,opt,name=denom,proto3" json:"denom,omitempty"`
 	// enabled defines the token mapping enable status
 	Enabled bool `protobuf:"varint,3,opt,name=enabled,proto3" json:"enabled,omitempty"`
-	// contract_owner is the an ENUM specifying the type of ERC20 owner (0 invalid, 1 ModuleAccount, 2 external address)
+	// contract_owner is the an ENUM specifying the type of ERC20 owner (0
+	// invalid, 1 ModuleAccount, 2 external address)
 	ContractOwner Owner `protobuf:"varint,4,opt,name=contract_owner,json=contractOwner,proto3,enum=evmos.erc20.v1.Owner" json:"contract_owner,omitempty"`
 }
 

--- a/evmos/x/erc20/types/events.pb.go
+++ b/evmos/x/erc20/types/events.pb.go
@@ -77,7 +77,8 @@ func (m *EventRegisterPair) GetErc20Address() string {
 	return ""
 }
 
-// EventToggleTokenConversion is an event emitted when a coin's token conversion is toggled.
+// EventToggleTokenConversion is an event emitted when a coin's token conversion
+// is toggled.
 type EventToggleTokenConversion struct {
 	// denom is the coin's denomination.
 	Denom string `protobuf:"bytes,1,opt,name=denom,proto3" json:"denom,omitempty"`
@@ -224,7 +225,8 @@ type EventConvertERC20 struct {
 	Amount string `protobuf:"bytes,3,opt,name=amount,proto3" json:"amount,omitempty"`
 	// denom is the coin's denomination.
 	Denom string `protobuf:"bytes,4,opt,name=denom,proto3" json:"denom,omitempty"`
-	// contract_address of an ERC20 token contract, that is registered in a token pair
+	// contract_address of an ERC20 token contract, that is registered in a token
+	// pair
 	ContractAddress string `protobuf:"bytes,5,opt,name=contract_address,json=contractAddress,proto3" json:"contract_address,omitempty"`
 }
 

--- a/evmos/x/erc20/types/genesis.pb.go
+++ b/evmos/x/erc20/types/genesis.pb.go
@@ -80,10 +80,12 @@ func (m *GenesisState) GetTokenPairs() []TokenPair {
 
 // Params defines the erc20 module params
 type Params struct {
-	// enable_erc20 is the parameter to enable the conversion of Cosmos coins <--> ERC20 tokens.
+	// enable_erc20 is the parameter to enable the conversion of Cosmos coins <-->
+	// ERC20 tokens.
 	EnableErc20 bool `protobuf:"varint,1,opt,name=enable_erc20,json=enableErc20,proto3" json:"enable_erc20,omitempty"`
-	// enable_evm_hook is the parameter to enable the EVM hook that converts an ERC20 token to a Cosmos
-	// Coin by transferring the Tokens through a MsgEthereumTx to the ModuleAddress Ethereum address.
+	// enable_evm_hook is the parameter to enable the EVM hook that converts an
+	// ERC20 token to a Cosmos Coin by transferring the Tokens through a
+	// MsgEthereumTx to the ModuleAddress Ethereum address.
 	EnableEVMHook bool `protobuf:"varint,2,opt,name=enable_evm_hook,json=enableEvmHook,proto3" json:"enable_evm_hook,omitempty"`
 }
 

--- a/evmos/x/erc20/types/query.pb.go
+++ b/evmos/x/erc20/types/query.pb.go
@@ -183,7 +183,8 @@ func (m *QueryTokenPairRequest) GetToken() string {
 // QueryTokenPairResponse is the response type for the Query/TokenPair RPC
 // method.
 type QueryTokenPairResponse struct {
-	// token_pairs returns the info about a registered token pair for the erc20 module
+	// token_pairs returns the info about a registered token pair for the erc20
+	// module
 	TokenPair TokenPair `protobuf:"bytes,1,opt,name=token_pair,json=tokenPair,proto3" json:"token_pair"`
 }
 

--- a/evmos/x/erc20/types/tx.pb.go
+++ b/evmos/x/erc20/types/tx.pb.go
@@ -35,12 +35,13 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // MsgConvertCoin defines a Msg to convert a native Cosmos coin to a ERC20 token
 type MsgConvertCoin struct {
-	// coin is a Cosmos coin whose denomination is registered in a token pair. The coin
-	// amount defines the amount of coins to convert.
+	// coin is a Cosmos coin whose denomination is registered in a token pair. The
+	// coin amount defines the amount of coins to convert.
 	Coin types.Coin `protobuf:"bytes,1,opt,name=coin,proto3" json:"coin"`
 	// receiver is the hex address to receive ERC20 token
 	Receiver string `protobuf:"bytes,2,opt,name=receiver,proto3" json:"receiver,omitempty"`
-	// sender is the cosmos bech32 address from the owner of the given Cosmos coins
+	// sender is the cosmos bech32 address from the owner of the given Cosmos
+	// coins
 	Sender string `protobuf:"bytes,3,opt,name=sender,proto3" json:"sender,omitempty"`
 }
 
@@ -138,7 +139,8 @@ var xxx_messageInfo_MsgConvertCoinResponse proto.InternalMessageInfo
 // MsgConvertERC20 defines a Msg to convert a ERC20 token to a native Cosmos
 // coin.
 type MsgConvertERC20 struct {
-	// contract_address of an ERC20 token contract, that is registered in a token pair
+	// contract_address of an ERC20 token contract, that is registered in a token
+	// pair
 	ContractAddress string `protobuf:"bytes,1,opt,name=contract_address,json=contractAddress,proto3" json:"contract_address,omitempty"`
 	// amount of ERC20 tokens to convert
 	Amount github_com_cosmos_cosmos_sdk_types.Int `protobuf:"bytes,2,opt,name=amount,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Int" json:"amount"`
@@ -405,8 +407,9 @@ type MsgClient interface {
 	// ConvertERC20 mints a native Cosmos coin representation of the ERC20 token
 	// contract that is registered on the token mapping.
 	ConvertERC20(ctx context.Context, in *MsgConvertERC20, opts ...grpc.CallOption) (*MsgConvertERC20Response, error)
-	// UpdateParams defined a governance operation for updating the x/erc20 module parameters.
-	// The authority is hard-coded to the Cosmos SDK x/gov module account
+	// UpdateParams defined a governance operation for updating the x/erc20 module
+	// parameters. The authority is hard-coded to the Cosmos SDK x/gov module
+	// account
 	UpdateParams(ctx context.Context, in *MsgUpdateParams, opts ...grpc.CallOption) (*MsgUpdateParamsResponse, error)
 }
 
@@ -453,8 +456,9 @@ type MsgServer interface {
 	// ConvertERC20 mints a native Cosmos coin representation of the ERC20 token
 	// contract that is registered on the token mapping.
 	ConvertERC20(context.Context, *MsgConvertERC20) (*MsgConvertERC20Response, error)
-	// UpdateParams defined a governance operation for updating the x/erc20 module parameters.
-	// The authority is hard-coded to the Cosmos SDK x/gov module account
+	// UpdateParams defined a governance operation for updating the x/erc20 module
+	// parameters. The authority is hard-coded to the Cosmos SDK x/gov module
+	// account
 	UpdateParams(context.Context, *MsgUpdateParams) (*MsgUpdateParamsResponse, error)
 }
 

--- a/proto/buf.gen.gogo.yaml
+++ b/proto/buf.gen.gogo.yaml
@@ -1,8 +1,8 @@
 version: v1
 plugins:
   - name: gocosmos
-    out: ..
+    out: .
     opt: plugins=grpc,Mgoogle/protobuf/any.proto=github.com/cosmos/cosmos-sdk/codec/types
   - name: grpc-gateway
-    out: ..
+    out: .
     opt: logtostderr=true,allow_colon_final_segments=true

--- a/proto/evmos/erc20/v1/erc20.proto
+++ b/proto/evmos/erc20/v1/erc20.proto
@@ -27,7 +27,8 @@ message TokenPair {
   string denom = 2;
   // enabled defines the token mapping enable status
   bool enabled = 3;
-  // contract_owner is the an ENUM specifying the type of ERC20 owner (0 invalid, 1 ModuleAccount, 2 external address)
+  // contract_owner is the an ENUM specifying the type of ERC20 owner (0
+  // invalid, 1 ModuleAccount, 2 external address)
   Owner contract_owner = 4;
 }
 
@@ -40,7 +41,8 @@ message RegisterCoinProposal {
   // description of the proposal
   string description = 2;
   // metadata slice of the native Cosmos coins
-  repeated cosmos.bank.v1beta1.Metadata metadata = 3 [(gogoproto.nullable) = false];
+  repeated cosmos.bank.v1beta1.Metadata metadata = 3
+      [ (gogoproto.nullable) = false ];
 }
 
 // RegisterERC20Proposal is a gov Content type to register a token pair for an
@@ -72,5 +74,6 @@ message ToggleTokenConversionProposal {
 // the RegisterCoinProposal content.
 message ProposalMetadata {
   // metadata slice of the native Cosmos coins
-  repeated cosmos.bank.v1beta1.Metadata metadata = 1 [(gogoproto.nullable) = false];
+  repeated cosmos.bank.v1beta1.Metadata metadata = 1
+      [ (gogoproto.nullable) = false ];
 }

--- a/proto/evmos/erc20/v1/events.proto
+++ b/proto/evmos/erc20/v1/events.proto
@@ -11,7 +11,8 @@ message EventRegisterPair {
   string erc20_address = 2;
 }
 
-// EventToggleTokenConversion is an event emitted when a coin's token conversion is toggled.
+// EventToggleTokenConversion is an event emitted when a coin's token conversion
+// is toggled.
 message EventToggleTokenConversion {
   // denom is the coin's denomination.
   string denom = 1;
@@ -43,6 +44,7 @@ message EventConvertERC20 {
   string amount = 3;
   // denom is the coin's denomination.
   string denom = 4;
-  // contract_address of an ERC20 token contract, that is registered in a token pair
+  // contract_address of an ERC20 token contract, that is registered in a token
+  // pair
   string contract_address = 5;
 }

--- a/proto/evmos/erc20/v1/genesis.proto
+++ b/proto/evmos/erc20/v1/genesis.proto
@@ -9,16 +9,18 @@ option go_package = "github.com/settlus/chain/evmos/x/erc20/types";
 // GenesisState defines the module's genesis state.
 message GenesisState {
   // params are the erc20 module parameters at genesis
-  Params params = 1 [(gogoproto.nullable) = false];
+  Params params = 1 [ (gogoproto.nullable) = false ];
   // token_pairs is a slice of the registered token pairs at genesis
-  repeated TokenPair token_pairs = 2 [(gogoproto.nullable) = false];
+  repeated TokenPair token_pairs = 2 [ (gogoproto.nullable) = false ];
 }
 
 // Params defines the erc20 module params
 message Params {
-  // enable_erc20 is the parameter to enable the conversion of Cosmos coins <--> ERC20 tokens.
+  // enable_erc20 is the parameter to enable the conversion of Cosmos coins <-->
+  // ERC20 tokens.
   bool enable_erc20 = 1;
-  // enable_evm_hook is the parameter to enable the EVM hook that converts an ERC20 token to a Cosmos
-  // Coin by transferring the Tokens through a MsgEthereumTx to the ModuleAddress Ethereum address.
-  bool enable_evm_hook = 2 [(gogoproto.customname) = "EnableEVMHook"];
+  // enable_evm_hook is the parameter to enable the EVM hook that converts an
+  // ERC20 token to a Cosmos Coin by transferring the Tokens through a
+  // MsgEthereumTx to the ModuleAddress Ethereum address.
+  bool enable_evm_hook = 2 [ (gogoproto.customname) = "EnableEVMHook" ];
 }

--- a/proto/evmos/erc20/v1/query.proto
+++ b/proto/evmos/erc20/v1/query.proto
@@ -38,7 +38,7 @@ message QueryTokenPairsRequest {
 // method.
 message QueryTokenPairsResponse {
   // token_pairs is a slice of registered token pairs for the erc20 module
-  repeated TokenPair token_pairs = 1 [(gogoproto.nullable) = false];
+  repeated TokenPair token_pairs = 1 [ (gogoproto.nullable) = false ];
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
@@ -53,8 +53,9 @@ message QueryTokenPairRequest {
 // QueryTokenPairResponse is the response type for the Query/TokenPair RPC
 // method.
 message QueryTokenPairResponse {
-  // token_pairs returns the info about a registered token pair for the erc20 module
-  TokenPair token_pair = 1 [(gogoproto.nullable) = false];
+  // token_pairs returns the info about a registered token pair for the erc20
+  // module
+  TokenPair token_pair = 1 [ (gogoproto.nullable) = false ];
 }
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.
@@ -64,5 +65,5 @@ message QueryParamsRequest {}
 // method.
 message QueryParamsResponse {
   // params are the erc20 module parameters
-  Params params = 1 [(gogoproto.nullable) = false];
+  Params params = 1 [ (gogoproto.nullable) = false ];
 }

--- a/proto/evmos/erc20/v1/tx.proto
+++ b/proto/evmos/erc20/v1/tx.proto
@@ -22,19 +22,21 @@ service Msg {
   rpc ConvertERC20(MsgConvertERC20) returns (MsgConvertERC20Response) {
     option (google.api.http).get = "/evmos/erc20/v1/tx/convert_erc20";
   };
-  // UpdateParams defined a governance operation for updating the x/erc20 module parameters.
-  // The authority is hard-coded to the Cosmos SDK x/gov module account
+  // UpdateParams defined a governance operation for updating the x/erc20 module
+  // parameters. The authority is hard-coded to the Cosmos SDK x/gov module
+  // account
   rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
 }
 
 // MsgConvertCoin defines a Msg to convert a native Cosmos coin to a ERC20 token
 message MsgConvertCoin {
-  // coin is a Cosmos coin whose denomination is registered in a token pair. The coin
-  // amount defines the amount of coins to convert.
-  cosmos.base.v1beta1.Coin coin = 1 [(gogoproto.nullable) = false];
+  // coin is a Cosmos coin whose denomination is registered in a token pair. The
+  // coin amount defines the amount of coins to convert.
+  cosmos.base.v1beta1.Coin coin = 1 [ (gogoproto.nullable) = false ];
   // receiver is the hex address to receive ERC20 token
   string receiver = 2;
-  // sender is the cosmos bech32 address from the owner of the given Cosmos coins
+  // sender is the cosmos bech32 address from the owner of the given Cosmos
+  // coins
   string sender = 3;
 }
 
@@ -44,10 +46,14 @@ message MsgConvertCoinResponse {}
 // MsgConvertERC20 defines a Msg to convert a ERC20 token to a native Cosmos
 // coin.
 message MsgConvertERC20 {
-  // contract_address of an ERC20 token contract, that is registered in a token pair
+  // contract_address of an ERC20 token contract, that is registered in a token
+  // pair
   string contract_address = 1;
   // amount of ERC20 tokens to convert
-  string amount = 2 [(gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int", (gogoproto.nullable) = false];
+  string amount = 2 [
+    (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Int",
+    (gogoproto.nullable) = false
+  ];
   // receiver is the bech32 address to receive native Cosmos coins
   string receiver = 3;
   // sender is the hex address from the owner of the given ERC20 tokens
@@ -63,11 +69,11 @@ message MsgUpdateParams {
   option (cosmos.msg.v1.signer) = "authority";
 
   // authority is the address of the governance account.
-  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string authority = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
 
   // params defines the x/evm parameters to update.
   // NOTE: All parameters must be supplied.
-  Params params = 2 [(gogoproto.nullable) = false];
+  Params params = 2 [ (gogoproto.nullable) = false ];
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a

--- a/proto/interop/service.proto
+++ b/proto/interop/service.proto
@@ -14,6 +14,4 @@ message OwnerOfRequest {
   string block_hash = 4;
 }
 
-message OwnerOfResponse {
-  string owner = 1;
-}
+message OwnerOfResponse { string owner = 1; }

--- a/proto/settlus/nftownership/query.proto
+++ b/proto/settlus/nftownership/query.proto
@@ -17,8 +17,9 @@ service Query {
 
   // Queries a list of GetNftOwner items.
   rpc GetNftOwner(QueryGetNftOwnerRequest) returns (QueryGetNftOwnerResponse) {
-    option (google.api.http).get = "/settlus/nftownership/get_nft_owner/"
-                                   "{chain_id}/{contract_address}/{token_id_hex}";
+    option (google.api.http).get =
+        "/settlus/nftownership/get_nft_owner/"
+        "{chain_id}/{contract_address}/{token_id_hex}";
   }
 }
 
@@ -38,5 +39,6 @@ message QueryGetNftOwnerRequest {
   string token_id_hex = 3;
 }
 
-// QueryGetNftOwnerResponse is response type for the Query/GetNftOwner RPC method.
+// QueryGetNftOwnerResponse is response type for the Query/GetNftOwner RPC
+// method.
 message QueryGetNftOwnerResponse { string owner_address = 1; }

--- a/proto/settlus/oracle/v1alpha1/query.proto
+++ b/proto/settlus/oracle/v1alpha1/query.proto
@@ -92,63 +92,75 @@ message QueryBlockDataRequest { string chain_id = 1; }
 // QueryBlockDataResponse is response type for the Query/BlockData RPC method.
 message QueryBlockDataResponse { BlockData block_data = 1; }
 
-// QueryAllBlockDataRequest is request type for the Query/AllBlockData RPC method.
+// QueryAllBlockDataRequest is request type for the Query/AllBlockData RPC
+// method.
 message QueryAllBlockDataRequest {}
 
-// QueryAllBlockDataResponse is response type for the Query/AllBlockData RPC method.
+// QueryAllBlockDataResponse is response type for the Query/AllBlockData RPC
+// method.
 message QueryAllBlockDataResponse {
   repeated BlockData block_data = 2 [ (gogoproto.nullable) = false ];
 }
 
-// QueryFeederDelegationRequest is request type for the Query/FeederDelegation RPC method.
+// QueryFeederDelegationRequest is request type for the Query/FeederDelegation
+// RPC method.
 message QueryFeederDelegationRequest { string validator_address = 1; }
 
-// QueryFeederDelegationResponse is response type for the Query/FeederDelegation RPC method.
+// QueryFeederDelegationResponse is response type for the Query/FeederDelegation
+// RPC method.
 message QueryFeederDelegationResponse {
   FeederDelegation feeder_delegation = 1;
 }
 
-// QueryAggregatePrevoteRequest is request type for the Query/AggregatePrevote RPC method.
+// QueryAggregatePrevoteRequest is request type for the Query/AggregatePrevote
+// RPC method.
 message QueryAggregatePrevoteRequest {
   string validator_address = 1;
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// QueryAggregatePrevoteResponse is response type for the Query/AggregatePrevote RPC method.
+// QueryAggregatePrevoteResponse is response type for the Query/AggregatePrevote
+// RPC method.
 message QueryAggregatePrevoteResponse {
   AggregatePrevote aggregate_prevote = 1;
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QueryAggregatePrevotesRequest is request type for the Query/AggregatePrevotes RPC method.
+// QueryAggregatePrevotesRequest is request type for the Query/AggregatePrevotes
+// RPC method.
 message QueryAggregatePrevotesRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 1;
 }
 
-// QueryAggregatePrevotesResponse is response type for the Query/AggregatePrevotes RPC method.
+// QueryAggregatePrevotesResponse is response type for the
+// Query/AggregatePrevotes RPC method.
 message QueryAggregatePrevotesResponse {
   repeated AggregatePrevote aggregate_prevotes = 1;
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QueryAggregateVoteRequest is request type for the Query/AggregateVote RPC method.
+// QueryAggregateVoteRequest is request type for the Query/AggregateVote RPC
+// method.
 message QueryAggregateVoteRequest {
   string validator_address = 1;
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// QueryAggregateVoteResponse is response type for the Query/AggregateVote RPC method.
+// QueryAggregateVoteResponse is response type for the Query/AggregateVote RPC
+// method.
 message QueryAggregateVoteResponse {
   AggregateVote aggregate_vote = 1;
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QueryAggregateVotesRequest is request type for the Query/AggregateVotes RPC method.
+// QueryAggregateVotesRequest is request type for the Query/AggregateVotes RPC
+// method.
 message QueryAggregateVotesRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// QueryAggregateVotesResponse is response type for the Query/AggregateVotes RPC method.
+// QueryAggregateVotesResponse is response type for the Query/AggregateVotes RPC
+// method.
 message QueryAggregateVotesResponse {
   repeated AggregateVote aggregate_votes = 1;
   cosmos.base.query.v1beta1.PageResponse pagination = 2;

--- a/proto/settlus/settlement/query.proto
+++ b/proto/settlus/settlement/query.proto
@@ -84,9 +84,7 @@ message TenantWithTreasury {
 
 message Treasury {
   string address = 1;
-  cosmos.base.v1beta1.Coin balance = 2 [
-    (gogoproto.nullable) = true
-  ];
+  cosmos.base.v1beta1.Coin balance = 2 [ (gogoproto.nullable) = true ];
 }
 
 // QueryTenantsRequest is request type for the Query/Tenants RPC method.

--- a/proto/settlus/settlement/settlement.proto
+++ b/proto/settlus/settlement/settlement.proto
@@ -38,7 +38,8 @@ message UTXR {
   string request_id = 1;
   string recipient = 2 [
     (gogoproto.customtype) = "github.com/settlus/chain/types.HexAddressString",
-    (gogoproto.nullable) = false];
+    (gogoproto.nullable) = false
+  ];
   cosmos.base.v1beta1.Coin amount = 3 [ (gogoproto.nullable) = false ];
   uint64 payout_block = 4;
 }

--- a/proto/settlus/settlement/tx.proto
+++ b/proto/settlus/settlement/tx.proto
@@ -12,11 +12,15 @@ service Msg {
   rpc Record(MsgRecord) returns (MsgRecordResponse);
   rpc Cancel(MsgCancel) returns (MsgCancelResponse);
   rpc CreateTenant(MsgCreateTenant) returns (MsgCreateTenantResponse);
-  rpc CreateTenantWithMintableContract(MsgCreateTenantWithMintableContract) returns (MsgCreateTenantResponse);
+  rpc CreateTenantWithMintableContract(MsgCreateTenantWithMintableContract)
+      returns (MsgCreateTenantResponse);
   rpc AddTenantAdmin(MsgAddTenantAdmin) returns (MsgAddTenantAdminResponse);
-  rpc RemoveTenantAdmin(MsgRemoveTenantAdmin) returns (MsgRemoveTenantAdminResponse);
-  rpc UpdateTenantPayoutPeriod(MsgUpdateTenantPayoutPeriod) returns (MsgUpdateTenantPayoutPeriodResponse);
-  rpc DepositToTreasury(MsgDepositToTreasury) returns (MsgDepositToTreasuryResponse);
+  rpc RemoveTenantAdmin(MsgRemoveTenantAdmin)
+      returns (MsgRemoveTenantAdminResponse);
+  rpc UpdateTenantPayoutPeriod(MsgUpdateTenantPayoutPeriod)
+      returns (MsgUpdateTenantPayoutPeriodResponse);
+  rpc DepositToTreasury(MsgDepositToTreasury)
+      returns (MsgDepositToTreasuryResponse);
 }
 
 // MsgRecordRevenue is the RecordRevenue request type.
@@ -33,7 +37,8 @@ message MsgRecord {
   string metadata = 8 [ (gogoproto.nullable) = true ];
 }
 
-// MsgRecordResponse defines the response structure for executing a MsgRecord message.
+// MsgRecordResponse defines the response structure for executing a MsgRecord
+// message.
 message MsgRecordResponse {
   uint64 utxr_id = 1;
   string recipient = 2;
@@ -48,7 +53,8 @@ message MsgCancel {
   string request_id = 3;
 }
 
-// MsgCancelResponse defines the response structure for executing a MsgCancel message.
+// MsgCancelResponse defines the response structure for executing a MsgCancel
+// message.
 message MsgCancelResponse {}
 
 // MsgCreateTenant is the CreateTenant request type.
@@ -60,12 +66,12 @@ message MsgCreateTenant {
   uint64 payout_period = 3;
 }
 
-// MsgCreateTenantResponse defines the response structure for executing a MsgCreateTenant message.
-message MsgCreateTenantResponse {
-  uint64 tenant_id = 1;
-}
+// MsgCreateTenantResponse defines the response structure for executing a
+// MsgCreateTenant message.
+message MsgCreateTenantResponse { uint64 tenant_id = 1; }
 
-// MsgCreateTenantWithMintableContract is the CreateTenantWithMintableContract request type.
+// MsgCreateTenantWithMintableContract is the CreateTenantWithMintableContract
+// request type.
 message MsgCreateTenantWithMintableContract {
   option (cosmos.msg.v1.signer) = "sender";
 
@@ -84,7 +90,8 @@ message MsgAddTenantAdmin {
   string new_admin = 3;
 }
 
-// MsgAddTenantAdminResponse defines the response structure for executing a MsgAddTenantAdmin message.
+// MsgAddTenantAdminResponse defines the response structure for executing a
+// MsgAddTenantAdmin message.
 message MsgAddTenantAdminResponse {}
 
 // MsgRemoveTenantAdmin is the RemoveTenantAdmin request type.
@@ -96,7 +103,8 @@ message MsgRemoveTenantAdmin {
   string admin_to_remove = 3;
 }
 
-// MsgRemoveTenantAdminResponse defines the response structure for executing a MsgRemoveTenantAdmin message.
+// MsgRemoveTenantAdminResponse defines the response structure for executing a
+// MsgRemoveTenantAdmin message.
 message MsgRemoveTenantAdminResponse {}
 
 // MsgUpdateTenantPayoutPeriod is the UpdateTenantPayoutPeriod request type.
@@ -108,7 +116,8 @@ message MsgUpdateTenantPayoutPeriod {
   uint64 payout_period = 3;
 }
 
-// MsgUpdateTenantPayoutPeriodResponse defines the response structure for executing a MsgUpdateTenantPayoutPeriod message.
+// MsgUpdateTenantPayoutPeriodResponse defines the response structure for
+// executing a MsgUpdateTenantPayoutPeriod message.
 message MsgUpdateTenantPayoutPeriodResponse {}
 
 // MsgPayout is the Payout request type.
@@ -120,5 +129,6 @@ message MsgDepositToTreasury {
   cosmos.base.v1beta1.Coin amount = 3 [ (gogoproto.nullable) = false ];
 }
 
-// MsgPayoutResponse defines the response structure for executing a MsgPayout message.
+// MsgPayoutResponse defines the response structure for executing a MsgPayout
+// message.
 message MsgDepositToTreasuryResponse {}

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -5,23 +5,22 @@
 # docker run --rm -v $(pwd):/workspace --workdir /workspace cosmossdk-proto sh ./scripts/protocgen.sh
 
 echo "Formatting protobuf files"
-find ./ -name "*.proto" -exec clang-format -i {} \;
+apk add --no-cache clang-extra-tools
+find ./proto -name "*.proto" -exec clang-format -i {} \;
 
 set -e
 
 echo "Generating gogo proto code"
-cd ./proto
-proto_dirs=$(find ./ -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
+proto_dirs=$(find ./proto -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   proto_files=$(find "${dir}" -maxdepth 1 -name '*.proto')
   for file in $proto_files; do
-    if grep -q "option go_package" "$file"; then
-      buf generate --template buf.gen.gogo.yaml "$file"
+    # Check if the go_package in the file is pointing to settlus
+    if grep -q "option go_package.*settlus" "$file"; then
+      buf generate --template proto/buf.gen.gogo.yaml "$file"
     fi
   done
 done
-
-cd ..
 
 cp -r github.com/settlus/chain/evmos/* ./evmos
 cp -r github.com/settlus/chain/x/* ./x

--- a/x/nftownership/types/query.pb.go
+++ b/x/nftownership/types/query.pb.go
@@ -174,7 +174,8 @@ func (m *QueryGetNftOwnerRequest) GetTokenIdHex() string {
 	return ""
 }
 
-// QueryGetNftOwnerResponse is response type for the Query/GetNftOwner RPC method.
+// QueryGetNftOwnerResponse is response type for the Query/GetNftOwner RPC
+// method.
 type QueryGetNftOwnerResponse struct {
 	OwnerAddress string `protobuf:"bytes,1,opt,name=owner_address,json=ownerAddress,proto3" json:"owner_address,omitempty"`
 }

--- a/x/oracle/types/query.pb.go
+++ b/x/oracle/types/query.pb.go
@@ -205,7 +205,8 @@ func (m *QueryBlockDataResponse) GetBlockData() *BlockData {
 	return nil
 }
 
-// QueryAllBlockDataRequest is request type for the Query/AllBlockData RPC method.
+// QueryAllBlockDataRequest is request type for the Query/AllBlockData RPC
+// method.
 type QueryAllBlockDataRequest struct {
 }
 
@@ -242,7 +243,8 @@ func (m *QueryAllBlockDataRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryAllBlockDataRequest proto.InternalMessageInfo
 
-// QueryAllBlockDataResponse is response type for the Query/AllBlockData RPC method.
+// QueryAllBlockDataResponse is response type for the Query/AllBlockData RPC
+// method.
 type QueryAllBlockDataResponse struct {
 	BlockData []BlockData `protobuf:"bytes,2,rep,name=block_data,json=blockData,proto3" json:"block_data"`
 }
@@ -287,7 +289,8 @@ func (m *QueryAllBlockDataResponse) GetBlockData() []BlockData {
 	return nil
 }
 
-// QueryFeederDelegationRequest is request type for the Query/FeederDelegation RPC method.
+// QueryFeederDelegationRequest is request type for the Query/FeederDelegation
+// RPC method.
 type QueryFeederDelegationRequest struct {
 	ValidatorAddress string `protobuf:"bytes,1,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
 }
@@ -332,7 +335,8 @@ func (m *QueryFeederDelegationRequest) GetValidatorAddress() string {
 	return ""
 }
 
-// QueryFeederDelegationResponse is response type for the Query/FeederDelegation RPC method.
+// QueryFeederDelegationResponse is response type for the Query/FeederDelegation
+// RPC method.
 type QueryFeederDelegationResponse struct {
 	FeederDelegation *FeederDelegation `protobuf:"bytes,1,opt,name=feeder_delegation,json=feederDelegation,proto3" json:"feeder_delegation,omitempty"`
 }
@@ -377,7 +381,8 @@ func (m *QueryFeederDelegationResponse) GetFeederDelegation() *FeederDelegation 
 	return nil
 }
 
-// QueryAggregatePrevoteRequest is request type for the Query/AggregatePrevote RPC method.
+// QueryAggregatePrevoteRequest is request type for the Query/AggregatePrevote
+// RPC method.
 type QueryAggregatePrevoteRequest struct {
 	ValidatorAddress string             `protobuf:"bytes,1,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
 	Pagination       *query.PageRequest `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -430,7 +435,8 @@ func (m *QueryAggregatePrevoteRequest) GetPagination() *query.PageRequest {
 	return nil
 }
 
-// QueryAggregatePrevoteResponse is response type for the Query/AggregatePrevote RPC method.
+// QueryAggregatePrevoteResponse is response type for the Query/AggregatePrevote
+// RPC method.
 type QueryAggregatePrevoteResponse struct {
 	AggregatePrevote *AggregatePrevote   `protobuf:"bytes,1,opt,name=aggregate_prevote,json=aggregatePrevote,proto3" json:"aggregate_prevote,omitempty"`
 	Pagination       *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -483,7 +489,8 @@ func (m *QueryAggregatePrevoteResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
-// QueryAggregatePrevotesRequest is request type for the Query/AggregatePrevotes RPC method.
+// QueryAggregatePrevotesRequest is request type for the Query/AggregatePrevotes
+// RPC method.
 type QueryAggregatePrevotesRequest struct {
 	Pagination *query.PageRequest `protobuf:"bytes,1,opt,name=pagination,proto3" json:"pagination,omitempty"`
 }
@@ -528,7 +535,8 @@ func (m *QueryAggregatePrevotesRequest) GetPagination() *query.PageRequest {
 	return nil
 }
 
-// QueryAggregatePrevotesResponse is response type for the Query/AggregatePrevotes RPC method.
+// QueryAggregatePrevotesResponse is response type for the
+// Query/AggregatePrevotes RPC method.
 type QueryAggregatePrevotesResponse struct {
 	AggregatePrevotes []*AggregatePrevote `protobuf:"bytes,1,rep,name=aggregate_prevotes,json=aggregatePrevotes,proto3" json:"aggregate_prevotes,omitempty"`
 	Pagination        *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -581,7 +589,8 @@ func (m *QueryAggregatePrevotesResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
-// QueryAggregateVoteRequest is request type for the Query/AggregateVote RPC method.
+// QueryAggregateVoteRequest is request type for the Query/AggregateVote RPC
+// method.
 type QueryAggregateVoteRequest struct {
 	ValidatorAddress string             `protobuf:"bytes,1,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
 	Pagination       *query.PageRequest `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -634,7 +643,8 @@ func (m *QueryAggregateVoteRequest) GetPagination() *query.PageRequest {
 	return nil
 }
 
-// QueryAggregateVoteResponse is response type for the Query/AggregateVote RPC method.
+// QueryAggregateVoteResponse is response type for the Query/AggregateVote RPC
+// method.
 type QueryAggregateVoteResponse struct {
 	AggregateVote *AggregateVote      `protobuf:"bytes,1,opt,name=aggregate_vote,json=aggregateVote,proto3" json:"aggregate_vote,omitempty"`
 	Pagination    *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
@@ -687,7 +697,8 @@ func (m *QueryAggregateVoteResponse) GetPagination() *query.PageResponse {
 	return nil
 }
 
-// QueryAggregateVotesRequest is request type for the Query/AggregateVotes RPC method.
+// QueryAggregateVotesRequest is request type for the Query/AggregateVotes RPC
+// method.
 type QueryAggregateVotesRequest struct {
 	Pagination *query.PageRequest `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
 }
@@ -732,7 +743,8 @@ func (m *QueryAggregateVotesRequest) GetPagination() *query.PageRequest {
 	return nil
 }
 
-// QueryAggregateVotesResponse is response type for the Query/AggregateVotes RPC method.
+// QueryAggregateVotesResponse is response type for the Query/AggregateVotes RPC
+// method.
 type QueryAggregateVotesResponse struct {
 	AggregateVotes []*AggregateVote    `protobuf:"bytes,1,rep,name=aggregate_votes,json=aggregateVotes,proto3" json:"aggregate_votes,omitempty"`
 	Pagination     *query.PageResponse `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`

--- a/x/settlement/types/tx.pb.go
+++ b/x/settlement/types/tx.pb.go
@@ -131,7 +131,8 @@ func (m *MsgRecord) GetMetadata() string {
 	return ""
 }
 
-// MsgRecordResponse defines the response structure for executing a MsgRecord message.
+// MsgRecordResponse defines the response structure for executing a MsgRecord
+// message.
 type MsgRecordResponse struct {
 	UtxrId    uint64 `protobuf:"varint,1,opt,name=utxr_id,json=utxrId,proto3" json:"utxr_id,omitempty"`
 	Recipient string `protobuf:"bytes,2,opt,name=recipient,proto3" json:"recipient,omitempty"`
@@ -245,7 +246,8 @@ func (m *MsgCancel) GetRequestId() string {
 	return ""
 }
 
-// MsgCancelResponse defines the response structure for executing a MsgCancel message.
+// MsgCancelResponse defines the response structure for executing a MsgCancel
+// message.
 type MsgCancelResponse struct {
 }
 
@@ -343,7 +345,8 @@ func (m *MsgCreateTenant) GetPayoutPeriod() uint64 {
 	return 0
 }
 
-// MsgCreateTenantResponse defines the response structure for executing a MsgCreateTenant message.
+// MsgCreateTenantResponse defines the response structure for executing a
+// MsgCreateTenant message.
 type MsgCreateTenantResponse struct {
 	TenantId uint64 `protobuf:"varint,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 }
@@ -388,7 +391,8 @@ func (m *MsgCreateTenantResponse) GetTenantId() uint64 {
 	return 0
 }
 
-// MsgCreateTenantWithMintableContract is the CreateTenantWithMintableContract request type.
+// MsgCreateTenantWithMintableContract is the CreateTenantWithMintableContract
+// request type.
 type MsgCreateTenantWithMintableContract struct {
 	Sender       string `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty"`
 	Denom        string `protobuf:"bytes,2,opt,name=denom,proto3" json:"denom,omitempty"`
@@ -547,7 +551,8 @@ func (m *MsgAddTenantAdmin) GetNewAdmin() string {
 	return ""
 }
 
-// MsgAddTenantAdminResponse defines the response structure for executing a MsgAddTenantAdmin message.
+// MsgAddTenantAdminResponse defines the response structure for executing a
+// MsgAddTenantAdmin message.
 type MsgAddTenantAdminResponse struct {
 }
 
@@ -645,7 +650,8 @@ func (m *MsgRemoveTenantAdmin) GetAdminToRemove() string {
 	return ""
 }
 
-// MsgRemoveTenantAdminResponse defines the response structure for executing a MsgRemoveTenantAdmin message.
+// MsgRemoveTenantAdminResponse defines the response structure for executing a
+// MsgRemoveTenantAdmin message.
 type MsgRemoveTenantAdminResponse struct {
 }
 
@@ -743,7 +749,8 @@ func (m *MsgUpdateTenantPayoutPeriod) GetPayoutPeriod() uint64 {
 	return 0
 }
 
-// MsgUpdateTenantPayoutPeriodResponse defines the response structure for executing a MsgUpdateTenantPayoutPeriod message.
+// MsgUpdateTenantPayoutPeriodResponse defines the response structure for
+// executing a MsgUpdateTenantPayoutPeriod message.
 type MsgUpdateTenantPayoutPeriodResponse struct {
 }
 
@@ -841,7 +848,8 @@ func (m *MsgDepositToTreasury) GetAmount() types.Coin {
 	return types.Coin{}
 }
 
-// MsgPayoutResponse defines the response structure for executing a MsgPayout message.
+// MsgPayoutResponse defines the response structure for executing a MsgPayout
+// message.
 type MsgDepositToTreasuryResponse struct {
 }
 


### PR DESCRIPTION
even though we had the following shell script to lint proto files, `clang-format` was not installed in the dockerfile.
```shell
echo "Formatting protobuf files"
find ./ -name "*.proto" -exec clang-format -i {} \;
```

Added a line which installs `clang-format`.
