### PR TITLE
ci: add docker ci

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# build
+build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 name: Docker
-# Build & Push builds the Settlus docker image on every push to main
+# builds the Settlus docker image on push to main & tags,
 # and pushes the image to https://ghcr.io/settlus/chain
 on:
   pull_request:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,69 @@
+name: Docker
+# Build & Push builds the Settlus docker image on every push to main
+# and pushes the image to https://ghcr.io/settlus/chain
+on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+  push:
+    branches:
+      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+-rc*" # Push events to matching v*, i.e. v1.0-rc1, v20.15.10-rc5
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: "SDK version (e.g 0.47.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: settlus/chain
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{version}},value=v${{ inputs.tags }},enable=${{ inputs.tags != '' }}
+          flavor: |
+            latest=false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to GitHub Packages
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM golang:1.21-alpine as builder
 
-ARG GITHUB_TOKEN
 ENV CGO_ENABLED=1 GO111MODULE=on GOOS=linux
 
 # install make
@@ -8,17 +7,27 @@ RUN apk update && \
     apk upgrade && \
     apk add --update --no-cache alpine-sdk linux-headers make
 
-WORKDIR /app
+WORKDIR /go/src/github.com/settlus/chain
+
 COPY . .
 
 RUN go mod download
-RUN make settlusd
 
-FROM alpine:latest
+# Dockerfile Cross-Compilation Guide
+# https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide
+ARG TARGETOS TARGETARCH
+
+# install simapp, remove packages
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make build
+
+FROM alpine:3
+
+EXPOSE 26656 26657 1317 9090 8545
 
 WORKDIR /app
 
-RUN apk add --no-cache ca-certificates
-COPY --from=builder /app/build/settlusd /usr/local/bin/
+RUN apk add --no-cache ca-certificates curl bash jq
+
+COPY --from=builder /go/src/github.com/settlus/chain/build/settlusd /usr/local/bin/
 
 ENTRYPOINT ["settlusd"]


### PR DESCRIPTION
add docker ci.
builds the Settlus docker image on push to main & tags, and pushes the image to https://ghcr.io/settlus/chain.