### PR TITLE
interop-node: return handleprevote with an error if fails to send prevote

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,6 @@ require (
 	github.com/cometbft/cometbft-db v0.7.0 // indirect
 	github.com/confio/ics23/go v0.9.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
-	github.com/cosmos/gogoproto v1.4.11 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
 	github.com/cosmos/iavl v0.19.6 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.12.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -444,8 +444,6 @@ github.com/cosmos/cosmos-proto v1.0.0-beta.3/go.mod h1:t8IASdLaAq+bbHbjq4p960Bvc
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
-github.com/cosmos/gogoproto v1.4.11 h1:LZcMHrx4FjUgrqQSWeaGC1v/TeuVFqSLa43CC6aWR2g=
-github.com/cosmos/gogoproto v1.4.11/go.mod h1:/g39Mh8m17X8Q/GDEs5zYTSNaNnInBSohtaxzQnYq1Y=
 github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4Y=
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cosmos/iavl v0.19.6 h1:XY78yEeNPrEYyNCKlqr9chrwoeSDJ0bV2VjocTk//OU=

--- a/tools/interop-node/feeder/block_feeder.go
+++ b/tools/interop-node/feeder/block_feeder.go
@@ -118,6 +118,7 @@ func (feeder *BlockFeeder) HandlePrevote(ctx context.Context, height int64) erro
 
 	if err := feeder.sendPrevote(ctx, blockDataStr, salt); err != nil {
 		feeder.logger.Error(fmt.Sprintf("failed to send prevote: %v", err))
+		return fmt.Errorf("failed to send prevote: %w", err)
 	}
 
 	feeder.lastPreVote = BlockVoteInfo{

--- a/tools/interop-node/feeder/block_feeder.go
+++ b/tools/interop-node/feeder/block_feeder.go
@@ -117,7 +117,6 @@ func (feeder *BlockFeeder) HandlePrevote(ctx context.Context, height int64) erro
 	}
 
 	if err := feeder.sendPrevote(ctx, blockDataStr, salt); err != nil {
-		feeder.logger.Error(fmt.Sprintf("failed to send prevote: %v", err))
 		return fmt.Errorf("failed to send prevote: %w", err)
 	}
 


### PR DESCRIPTION
return `handleprevote()` with an error if fails to send prevote.

updating `feeder.lastPrevote` without actually sending the prevote to Settlus can cause unexpected behaviors.