### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     if: ${{ always() && (needs.lint.result == 'success' || needs.test.result == 'success') }}
     strategy:
       matrix:
-        go-arch: ["amd64", "arm64"]
+        go-arch: ["amd64"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -74,10 +74,4 @@ jobs:
         run : go mod download
       - name: Build
         if: env.GIT_DIFF
-        run: CGO_ENABLED=1 CC=aarch64-unknown-linux-gnu-gcc GOOS=linux GOARCH=${{ matrix.go-arch }} make build
-      - name: Archive
-        uses: actions/upload-artifact@v4
-        with:
-          name: binaries-${{ matrix.go-arch }}
-          path: ./build/*
-        if: env.GIT_DIFF && github.event_name != 'pull_request'
+        run: GOOS=linux GOARCH=${{ matrix.go-arch }} make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,10 @@ name: CI
 #  This workflow is run on pushes to main & every Pull Requests except changes to tools/interop-node.
 on:
   pull_request:
-    paths-ignore:
-      - 'tools/interop-node/**'
   push:
     branches:
       - main
       - release/**
-    paths-ignore:
-      - 'tools/interop-node/**'
 
 permissions:
   contents: read
@@ -54,7 +50,7 @@ jobs:
     if: ${{ always() && (needs.lint.result == 'success' || needs.test.result == 'success') }}
     strategy:
       matrix:
-        go-arch: ["amd64"]
+        go-arch: ["amd64", "arm64"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -72,12 +68,13 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
+            .github/workflows/build.yml
       - name: Download Go Dependency
         if: env.GIT_DIFF
         run : go mod download
       - name: Build
         if: env.GIT_DIFF
-        run: GOARCH=${{ matrix.go-arch }} make build
+        run: CGO_ENABLED=1 CC=aarch64-unknown-linux-gnu-gcc GOOS=linux GOARCH=${{ matrix.go-arch }} make build
       - name: Archive
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 # This workflow helps with creating releases.
 # This job will only be triggered when a tag (vX.X.x) is pushed
 on:
-  pull_request:
   push:
     # Sequence of patterns matched against refs/tags
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Create release
         uses: goreleaser/goreleaser-action@v5
         with:
-          args: release build
+          args: build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           go-version: "1.21"
           check-latest: true
-      - name: Create release
-        uses: goreleaser/goreleaser-action@v5
-        with:
-          args: build
-        env:
+      - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
+      - name: Create release
+        run: make release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+# This workflow helps with creating releases.
+# This job will only be triggered when a tag (vX.X.x) is pushed
+on:
+  pull_request:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+permissions:
+  contents: write # for goreleaser/goreleaser-action to create a GitHub release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+          check-latest: true
+      - name: Create release
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          args: release build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,12 @@ ts-client/
 
 tmp-swagger-gen
 swagger-proto
+
+# Build
+vendor
+/build
+dist
+
+# Go
+go.work
+go.work.sum

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,21 +3,6 @@ before:
     - go mod download
 
 builds:
-  - id: "settlus-darwin"
-    main: ./cmd/settlusd
-    binary: bin/settlusd
-    env:
-      - CGO_ENABLED=1
-      - CC=o64-clang
-      - CXX=o64-clang++
-    goos:
-      - darwin
-    goarch:
-      - amd64
-    flags:
-      - -tags=cgo
-    ldflags:
-      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=settlusd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
   - id: "settlusd-darwin-arm64"
     main: ./cmd/settlusd
     binary: bin/settlusd
@@ -79,18 +64,90 @@ builds:
       - -buildmode=exe
     ldflags:
       - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=settlusd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
-
+  - id: "interop-node-darwin-arm64"
+    main: ./tools/interop-node
+    binary: bin/interop-node
+    env:
+      - CGO_ENABLED=1
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=interop-node -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "interop-node-linux"
+    main: ./tools/interop-node
+    binary: bin/interop-node
+    env:
+      - CGO_ENABLED=1
+      - CC=gcc
+      - CXX=g++
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=interop-node -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "interop-node-linux-arm64"
+    main: ./tools/interop-node
+    binary: bin/interop-node
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    goos:
+      - linux
+    goarch:
+      - arm64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=interop-node -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "interop-node-windows"
+    main: ./tools/interop-node
+    binary: bin/interop-node
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    goos:
+      - windows
+    goarch:
+      - amd64
+    flags:
+      - -tags=cgo
+      - -buildmode=exe
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=interop-node -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_{{ .Arch }}'
+  - id: settlusd
+    name_template: 'settlus_{{ .Version }}_{{- title .Os }}_{{ .Arch }}'
     format_overrides:
       - goos: windows
         format: zip
     builds:
-      - settlusd-darwin
       - settlusd-darwin-arm64
       - settlusd-windows
       - settlusd-linux
       - settlusd-linux-arm64
+
+  - id: interop-node 
+    name_template: 'interop-node_{{ .Version }}_{{- title .Os }}_{{ .Arch }}'
+    format_overrides:
+      - goos: windows
+        format: zip
+    builds:
+      - interop-node-darwin-arm64
+      - interop-node-windows
+      - interop-node-linux
+      - interop-node-linux-arm64
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,7 +91,7 @@ archives:
       - settlusd-windows
       - settlusd-linux
       - settlusd-linux-arm64
-  
+
 checksum:
   name_template: 'checksums.txt'
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,104 @@
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: "settlus-darwin"
+    main: ./cmd/settlusd
+    binary: bin/settlusd
+    env:
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=settlusd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "settlusd-darwin-arm64"
+    main: ./cmd/settlusd
+    binary: bin/settlusd
+    env:
+      - CGO_ENABLED=1
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=settlusd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "settlusd-linux"
+    main: ./cmd/settlusd
+    binary: bin/settlusd
+    env:
+      - CGO_ENABLED=1
+      - CC=gcc
+      - CXX=g++
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=settlusd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "settlusd-linux-arm64"
+    main: ./cmd/settlusd
+    binary: bin/settlusd
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    goos:
+      - linux
+    goarch:
+      - arm64
+    flags:
+      - -tags=cgo
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=settlusd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "settlusd-windows"
+    main: ./cmd/settlusd
+    binary: bin/settlusd
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    goos:
+      - windows
+    goarch:
+      - amd64
+    flags:
+      - -tags=cgo
+      - -buildmode=exe
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=settlus -X github.com/cosmos/cosmos-sdk/version.AppName=settlusd -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_{{ .Arch }}'
+    format_overrides:
+      - goos: windows
+        format: zip
+    builds:
+      - settlusd-darwin
+      - settlusd-darwin-arm64
+      - settlusd-windows
+      - settlusd-linux
+      - settlusd-linux-arm64
+  
+checksum:
+  name_template: 'checksums.txt'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+snapshot:
+  name_template: "{{ .Tag }}-next"


### PR DESCRIPTION
- when a new tag is pushed, `release.yml` workflow creates release binaries with different architectures and OSs.
- `release.yml` creates separate binaries for `settlusd` and `interop-node`
- remove archiving binaries from `build.yml`. only archive binaries in a release.

I have tested the release workflow in my forked repo. https://github.com/jacobhjkim/chain/releases/tag/v0.0.11