### PR TITLE
interop-node: derive address from either feeder's private key or aws kms

### DIFF
--- a/cmd/settlusd/config/config.go
+++ b/cmd/settlusd/config/config.go
@@ -1,9 +1,11 @@
 package config
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	evmtypes "github.com/settlus/chain/evmos/types"
 	"math/big"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	evmtypes "github.com/settlus/chain/evmos/types"
 )
 
 const (

--- a/tools/interop-node/client/settlus.go
+++ b/tools/interop-node/client/settlus.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/settlus/chain/app"
 	"github.com/settlus/chain/evmos/encoding"
-
 	"github.com/settlus/chain/tools/interop-node/config"
 	"github.com/settlus/chain/tools/interop-node/signer"
 )
@@ -63,7 +62,7 @@ type SettlusClient struct {
 }
 
 // NewSettlusClient creates a new SettlusClient instance
-func NewSettlusClient(config *config.Config, ctx context.Context, logger cometlog.Logger) (*SettlusClient, error) {
+func NewSettlusClient(config *config.Config, ctx context.Context, s signer.Signer, logger cometlog.Logger) (*SettlusClient, error) {
 	rpcClient, gRpcClient, err := getSettlusRpcs(config.Settlus.RpcUrl, config.Settlus.GrpcUrl, config.Settlus.Insecure)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create settlus rpc clients: %w", err)
@@ -89,7 +88,7 @@ func NewSettlusClient(config *config.Config, ctx context.Context, logger cometlo
 		chainId:       config.Settlus.ChainId,
 		gasLimit:      config.Settlus.GasLimit,
 		fees:          fees,
-		signer:        signer.NewSigner(ctx, config),
+		signer:        s,
 		accountnumber: account.GetAccountNumber(),
 		sequence:      account.GetSequence(),
 		logger:        logger,

--- a/tools/interop-node/cmd/config.go
+++ b/tools/interop-node/cmd/config.go
@@ -62,8 +62,7 @@ for oracle feeder.
 				Feeder: cfg.FeederConfig{
 					Topics:           "block",
 					Address:          "settlus1uad3rkzpcgrvytqnd5d77lrhxgv83qad782h92",
-					SignerMode:       "local",
-					Key:              "0123456789abcdef",
+					PrivateKey:       "0123456789abcdef",
 					ValidatorAddress: "settlusvaloper1x0foobar",
 				},
 				Chains: []cfg.ChainConfig{

--- a/tools/interop-node/cmd/config.go
+++ b/tools/interop-node/cmd/config.go
@@ -61,8 +61,8 @@ for oracle feeder.
 				},
 				Feeder: cfg.FeederConfig{
 					Topics:           "block",
-					Address:          "settlus1uad3rkzpcgrvytqnd5d77lrhxgv83qad782h92",
-					PrivateKey:       "0123456789abcdef",
+					SignerMode:       cfg.Local,
+					Key:              "",
 					ValidatorAddress: "settlusvaloper1x0foobar",
 				},
 				Chains: []cfg.ChainConfig{

--- a/tools/interop-node/config/config.go
+++ b/tools/interop-node/config/config.go
@@ -11,11 +11,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const (
-	AwsKms = "aws-kms"
-	Local  = "local"
-)
-
 type RuntimeConfig struct {
 	HomeDir    string
 	ConfigFile string
@@ -116,8 +111,8 @@ func (sc *SettlusConfig) Validate() error {
 type FeederConfig struct {
 	Topics           string `yaml:"topics"`
 	Address          string `yaml:"address"`
-	SignerMode       string `yaml:"signer_mode"`
-	Key              string `yaml:"key"`
+	AWSKMSKey        string `yaml:"aws_kms_key"`
+	PrivateKey       string `yaml:"private_key"`
 	ValidatorAddress string `yaml:"validator_address"`
 }
 
@@ -134,12 +129,12 @@ func (fc *FeederConfig) Validate() error {
 		return fmt.Errorf("validator_address must start with settlusvaloper1: %s", fc.ValidatorAddress)
 	}
 
-	if fc.SignerMode != AwsKms && fc.SignerMode != Local {
-		return fmt.Errorf("invalid signer_mode, must be one of: %s, %s", AwsKms, Local)
+	if fc.AWSKMSKey == "" && fc.PrivateKey == "" {
+		return fmt.Errorf("either kms_key or private_key must be provided")
 	}
 
-	if fc.Address == "" {
-		return fmt.Errorf("address must not be empty")
+	if fc.AWSKMSKey != "" && fc.PrivateKey != "" {
+		return fmt.Errorf("only one of kms_key or private_key must be provided")
 	}
 
 	return nil

--- a/tools/interop-node/feeder/block_feeder.go
+++ b/tools/interop-node/feeder/block_feeder.go
@@ -10,7 +10,6 @@ import (
 	"github.com/settlus/chain/tools/interop-node/client"
 	"github.com/settlus/chain/tools/interop-node/config"
 	"github.com/settlus/chain/tools/interop-node/subscriber"
-
 	oracletypes "github.com/settlus/chain/x/oracle/types"
 )
 

--- a/tools/interop-node/server/server.go
+++ b/tools/interop-node/server/server.go
@@ -44,22 +44,11 @@ func NewServer(
 	logger = logger.With("server", "interop-node")
 
 	s := signer.NewSigner(ctx, config)
-	switch config.Feeder.SignerMode {
-	case cfg.AwsKms:
-		address, err := types.GetAddressFromPubKey(s.PubKey())
-		if err != nil {
-			return nil, err
-		}
-		config.Feeder.Address = address
-	case cfg.Local:
-		address, err := types.GetAddressFromPrivKey(config.Feeder.Key)
-		if err != nil {
-			return nil, err
-		}
-		config.Feeder.Address = address
-	default:
-		return nil, fmt.Errorf("invalid signer mode, must be one of: %s, %s", cfg.AwsKms, cfg.Local)
+	address, err := types.GetAddressFromPubKey(s.PubKey())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get address from pubkey: %w", err)
 	}
+	config.Feeder.Address = address
 
 	sc, err := client.NewSettlusClient(config, ctx, s, logger)
 	if err != nil {

--- a/tools/interop-node/server/server.go
+++ b/tools/interop-node/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/settlus/chain/tools/interop-node/feeder"
 	"github.com/settlus/chain/tools/interop-node/signer"
 	"github.com/settlus/chain/tools/interop-node/subscriber"
+	"github.com/settlus/chain/tools/interop-node/types"
 	"github.com/settlus/chain/x/interop"
 )
 

--- a/tools/interop-node/signer/kms.go
+++ b/tools/interop-node/signer/kms.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"fmt"
 	"math/big"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -43,7 +44,7 @@ func NewKmsSigner(ctx context.Context, key string) Signer {
 	}
 
 	if err := signer.loadPubKey(); err != nil {
-		panic(err)
+		panic(fmt.Errorf("failed to load public key during kms signer initialization: %w", err))
 	}
 
 	return signer

--- a/tools/interop-node/signer/signer.go
+++ b/tools/interop-node/signer/signer.go
@@ -2,7 +2,6 @@ package signer
 
 import (
 	"context"
-	"fmt"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 
@@ -15,12 +14,8 @@ type Signer interface {
 }
 
 func NewSigner(ctx context.Context, config *configtypes.Config) Signer {
-	switch config.Feeder.SignerMode {
-	case configtypes.AwsKms:
-		return NewKmsSigner(ctx, config.Feeder.Key)
-	case configtypes.Local:
-		return NewLocalSigner(config.Feeder.Key)
-	default:
-		panic(fmt.Sprintf("invalid signer mode, must be one of: %s, %s", configtypes.AwsKms, configtypes.Local))
+	if config.Feeder.AWSKMSKey != "" {
+		return NewKmsSigner(ctx, config.Feeder.AWSKMSKey)
 	}
+	return NewLocalSigner(config.Feeder.PrivateKey)
 }

--- a/tools/interop-node/signer/signer.go
+++ b/tools/interop-node/signer/signer.go
@@ -2,6 +2,7 @@ package signer
 
 import (
 	"context"
+	"fmt"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 
@@ -14,8 +15,12 @@ type Signer interface {
 }
 
 func NewSigner(ctx context.Context, config *configtypes.Config) Signer {
-	if config.Feeder.AWSKMSKey != "" {
-		return NewKmsSigner(ctx, config.Feeder.AWSKMSKey)
+	switch config.Feeder.SignerMode {
+	case configtypes.AwsKms:
+		return NewKmsSigner(ctx, config.Feeder.Key)
+	case configtypes.Local:
+		return NewLocalSigner(config.Feeder.Key)
+	default:
+		panic(fmt.Sprintf("invalid signer mode, must be one of: %s, %s", configtypes.AwsKms, configtypes.Local))
 	}
-	return NewLocalSigner(config.Feeder.PrivateKey)
 }

--- a/tools/interop-node/types/util.go
+++ b/tools/interop-node/types/util.go
@@ -6,10 +6,7 @@ import (
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-
-	"github.com/settlus/chain/evmos/crypto/ethsecp256k1"
 )
 
 func PadBytes(pad int, b []byte) []byte {
@@ -35,16 +32,6 @@ func ValidateHexString(s string) bool {
 
 	_, err := hexutil.Decode(s)
 	return err == nil
-}
-
-// GetAddressFromPrivKey returns the address of a private key
-func GetAddressFromPrivKey(privKey string) (string, error) {
-	key := &ethsecp256k1.PrivKey{Key: common.FromHex(privKey)}
-	if key.PubKey() == nil {
-		return "", fmt.Errorf("failed to create private key")
-	}
-
-	return GetAddressFromPubKey(key.PubKey())
 }
 
 // GetAddressFromPubKey returns the address of a public key

--- a/tools/interop-node/types/util.go
+++ b/tools/interop-node/types/util.go
@@ -1,9 +1,15 @@
 package types
 
 import (
+	"fmt"
 	"strings"
 
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/settlus/chain/evmos/crypto/ethsecp256k1"
 )
 
 func PadBytes(pad int, b []byte) []byte {
@@ -29,4 +35,24 @@ func ValidateHexString(s string) bool {
 
 	_, err := hexutil.Decode(s)
 	return err == nil
+}
+
+// GetAddressFromPrivKey returns the address of a private key
+func GetAddressFromPrivKey(privKey string) (string, error) {
+	key := &ethsecp256k1.PrivKey{Key: common.FromHex(privKey)}
+	if key.PubKey() == nil {
+		return "", fmt.Errorf("failed to create private key")
+	}
+
+	return GetAddressFromPubKey(key.PubKey())
+}
+
+// GetAddressFromPubKey returns the address of a public key
+func GetAddressFromPubKey(pubKey cryptotypes.PubKey) (string, error) {
+	acc := authtypes.NewBaseAccount(pubKey.Address().Bytes(), pubKey, 0, 0)
+	if err := acc.Validate(); err != nil {
+		return "", fmt.Errorf("failed to validate account: %w", err)
+	}
+
+	return acc.GetAddress().String(), nil
 }

--- a/tools/interop-node/types/util_test.go
+++ b/tools/interop-node/types/util_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	settlusconfig "github.com/settlus/chain/cmd/settlusd/config"
 	"github.com/settlus/chain/tools/interop-node/types"
 )
 
@@ -93,6 +96,41 @@ func Test_ValidateHexString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			types.ValidateHexString(tt.args.s)
+		})
+	}
+}
+
+func Test_GetAccAddressFromPrivKey(t *testing.T) {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(settlusconfig.Bech32Prefix, settlusconfig.Bech32PrefixAccPub)
+
+	tests := []struct {
+		name    string
+		privKey string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid private key",
+			privKey: "290a6eedf1144d433e9b6a7071b97c9029efcf51a320dbc26b89ad7f39b706fb",
+			want:    "settlus1mnd2teke7w0heukka3cctuqkq3kzzazrygtv4e",
+			wantErr: false,
+		},
+		{
+			name:    "invalid private key",
+			privKey: "foo",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if actual, err := types.GetAddressFromPrivKey(tt.privKey); err != nil && !tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+			} else if actual != tt.want {
+				t.Errorf("actual = %v, want %v", actual, tt.want)
+			}
 		})
 	}
 }

--- a/tools/interop-node/types/util_test.go
+++ b/tools/interop-node/types/util_test.go
@@ -102,41 +102,6 @@ func Test_ValidateHexString(t *testing.T) {
 	}
 }
 
-func Test_GetAccAddressFromPrivKey(t *testing.T) {
-	config := sdk.GetConfig()
-	config.SetBech32PrefixForAccount(settlusconfig.Bech32Prefix, settlusconfig.Bech32PrefixAccPub)
-
-	tests := []struct {
-		name    string
-		privKey string
-		want    string
-		wantErr bool
-	}{
-		{
-			name:    "valid private key",
-			privKey: "290a6eedf1144d433e9b6a7071b97c9029efcf51a320dbc26b89ad7f39b706fb",
-			want:    "settlus1mnd2teke7w0heukka3cctuqkq3kzzazrygtv4e",
-			wantErr: false,
-		},
-		{
-			name:    "invalid private key",
-			privKey: "foo",
-			want:    "",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if actual, err := types.GetAddressFromPrivKey(tt.privKey); err != nil && !tt.wantErr {
-				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
-			} else if actual != tt.want {
-				t.Errorf("actual = %v, want %v", actual, tt.want)
-			}
-		})
-	}
-}
-
 func Test_GetAddressFromPubKey(t *testing.T) {
 	config := sdk.GetConfig()
 	config.SetBech32PrefixForAccount(settlusconfig.Bech32Prefix, settlusconfig.Bech32PrefixAccPub)

--- a/tools/interop-node/types/util_test.go
+++ b/tools/interop-node/types/util_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 
 	settlusconfig "github.com/settlus/chain/cmd/settlusd/config"
+	"github.com/settlus/chain/evmos/crypto/ethsecp256k1"
 	"github.com/settlus/chain/tools/interop-node/types"
 )
 
@@ -128,6 +130,41 @@ func Test_GetAccAddressFromPrivKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if actual, err := types.GetAddressFromPrivKey(tt.privKey); err != nil && !tt.wantErr {
 				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+			} else if actual != tt.want {
+				t.Errorf("actual = %v, want %v", actual, tt.want)
+			}
+		})
+	}
+}
+
+func Test_GetAddressFromPubKey(t *testing.T) {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(settlusconfig.Bech32Prefix, settlusconfig.Bech32PrefixAccPub)
+
+	tests := []struct {
+		name    string
+		pubKey  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid public key",
+			pubKey:  "023A67CE381ACA142344D9458BDAA8BC960CF852AB9D674765ABA8A70475804611",
+			want:    "settlus1mnd2teke7w0heukka3cctuqkq3kzzazrygtv4e",
+			wantErr: false,
+		},
+		{
+			name:    "invalid public key",
+			pubKey:  "foo",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if actual, err := types.GetAddressFromPubKey(&ethsecp256k1.PubKey{Key: common.FromHex(tt.pubKey)}); err != nil && !tt.wantErr {
+				t.Errorf("error = %v", err)
 			} else if actual != tt.want {
 				t.Errorf("actual = %v, want %v", actual, tt.want)
 			}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,7 +4,7 @@ const (
 	// MainnetChainID defines the Evmos EIP155 chain ID for mainnet
 	MainnetChainID = "settlus_5371-1"
 	// TestnetChainID defines the Evmos EIP155 chain ID for testnet
-	TestnetChainID = "settlus_1001-1"
+	TestnetChainID = "settlus_5372-1"
 	// BaseDenom defines the Evmos mainnet denomination
 	BaseDenom = "asetl"
 )


### PR DESCRIPTION
# PR Description
derive address from either feeder's private key or aws kms

## Changes
- during the server's initialization, we derive the feeder's bech32 address from either AWS Kms or private key.