### PR TITLE
ci: add patch version to docker image tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{version}},value=v${{ inputs.tags }},enable=${{ inputs.tags != '' }}
           flavor: |
             latest=false


### PR DESCRIPTION
add patch version to docker image tag. currently our docker image tag only includes the major and the minor version as you can see from this link. https://github.com/settlus/chain/pkgs/container/chain
