### PR TITLE
interop-node: fetch headers via HTTP polling, replace web socket

### DIFF
--- a/tools/interop-node/subscriber/ethereum_subscriber.go
+++ b/tools/interop-node/subscriber/ethereum_subscriber.go
@@ -179,28 +179,25 @@ func (sub *EthereumSubscriber) fetchLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			num, err := sub.client.BlockNumber(ctx)
+			blockNumber, err := sub.client.BlockNumber(ctx)
 			if err != nil {
 				sub.logger.Error(err.Error(), "from", "latest block")
 				continue
 			}
-			block, err := sub.client.BlockByNumber(ctx, big.NewInt(int64(num)))
+			block, err := sub.client.BlockByNumber(ctx, big.NewInt(int64(blockNumber)))
 			if err != nil {
-				sub.logger.Error(err.Error(), "from", "block fetch", "number", num)
+				sub.logger.Error(err.Error(), "from", "block fetch", "number", blockNumber)
 				continue
 			}
 			event, err := sub.parseBlock(block)
 			if err != nil {
-				sub.logger.Error(err.Error(), "from", "parse block", "number", num)
+				sub.logger.Error(err.Error(), "from", "parse block", "number", blockNumber)
 				continue
 			}
 
 			sub.dbCh <- event
 		case <-ctx.Done():
-			if err := ctx.Err(); err != nil {
-				sub.logger.Error(err.Error())
-			}
-			sub.logger.Info("fetchLoop done")
+			sub.logger.Info("fetchLoop stopped")
 			close(sub.dbCh)
 			return
 		}

--- a/tools/interop-node/subscriber/ethereum_subscriber.go
+++ b/tools/interop-node/subscriber/ethereum_subscriber.go
@@ -171,8 +171,10 @@ func (sub *EthereumSubscriber) dbLoop(ctx context.Context) {
 	}
 }
 
+const fetchInterval = 5 * time.Second
+
 func (sub *EthereumSubscriber) fetchLoop(ctx context.Context) {
-	ticker := time.NewTicker(5000 * time.Millisecond)
+	ticker := time.NewTicker(fetchInterval)
 
 	for {
 		select {


### PR DESCRIPTION
After the websocket disconnects, the latest header information ceases to update.
Instead of implementing a websocket reconnection logic, we have decided to switch to HTTP polling.