### PR TITLE
ci: setup go in codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,6 +49,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff
         with:


### PR DESCRIPTION
setup go in codeql workflow

<img width="1392" alt="Screenshot 2024-01-29 at 2 34 13 PM" src="https://github.com/settlus/chain/assets/32784118/27557d52-34f2-4169-84f9-57bbcd0f75aa">

codeql was complaining about the go version.