### PR TITLE
ci: allow text after release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)?" # Push events to matching v*, i.e. v1.0, v20.15.10, v1.2.3-hotfix, etc.
 
 permissions:
   contents: write # for goreleaser/goreleaser-action to create a GitHub release


### PR DESCRIPTION
allow text after release tag
i.e. v1.0, v20.15.10, v1.2.3-hotfix, etc.