### PR TITLE
interop-node: add fee-payer config

### DIFF
--- a/tools/interop-node/client/settlus.go
+++ b/tools/interop-node/client/settlus.go
@@ -53,6 +53,7 @@ type SettlusClient struct {
 	chainId  string
 	gasLimit uint64
 	fees     sdk.Coins
+	feePayer string
 
 	signer        signer.Signer
 	accountnumber uint64
@@ -88,6 +89,7 @@ func NewSettlusClient(config *config.Config, ctx context.Context, s signer.Signe
 		chainId:       config.Settlus.ChainId,
 		gasLimit:      config.Settlus.GasLimit,
 		fees:          fees,
+		feePayer:      config.Feeder.FeePayer,
 		signer:        s,
 		accountnumber: account.GetAccountNumber(),
 		sequence:      account.GetSequence(),
@@ -220,6 +222,14 @@ func (sc *SettlusClient) buildTx(msg sdk.Msg) ([]byte, error) {
 	}
 	txBuilder.SetGasLimit(sc.gasLimit)
 	txBuilder.SetFeeAmount(sc.fees)
+
+	if sc.feePayer != "" {
+		addr, err := sdk.AccAddressFromBech32(sc.feePayer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse fee payer address: %w", err)
+		}
+		txBuilder.SetFeePayer(addr)
+	}
 
 	pubKey := sc.signer.PubKey()
 

--- a/tools/interop-node/config/config.go
+++ b/tools/interop-node/config/config.go
@@ -121,8 +121,9 @@ func (sc *SettlusConfig) Validate() error {
 type FeederConfig struct {
 	Topics           string `yaml:"topics"`
 	SignerMode       string `yaml:"signer_mode"`
-	Address          string `yaml:"address"` // derived from private key or aws kms key id, no need to set manually
-	Key              string `yaml:"key"`     // aws kms key id or private key
+	Address          string `yaml:"address"`   // derived from private key or aws kms key id, no need to set manually
+	FeePayer         string `yaml:"fee_payer"` // optional fee payer address
+	Key              string `yaml:"key"`       // aws kms key id or private key
 	ValidatorAddress string `yaml:"validator_address"`
 }
 
@@ -153,6 +154,17 @@ func (fc *FeederConfig) Validate() error {
 
 	if fc.SignerMode == Local && len(fc.Key) != 64 {
 		return fmt.Errorf("invalid private key: %s", fc.Key)
+	}
+
+	if fc.FeePayer != "" {
+		if !strings.HasPrefix(fc.FeePayer, "settlus1") {
+			return fmt.Errorf("fee_payer must start with settlus1: %s", fc.FeePayer)
+		}
+
+		_, err := sdk.AccAddressFromBech32(fc.FeePayer)
+		if err != nil {
+			return fmt.Errorf("invalid fee_payer address: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
allow interop-node feeder to set fee-payer for oracle transactions.