### PR TITLE
chore(deps): bump settlus/cosmos-sdk from 3 to 4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -236,7 +236,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.22.2
 	// use Settlus flavored Cosmos-SDK https://github.com/settlus/cosmos-sdk/releases
-	github.com/cosmos/cosmos-sdk => github.com/settlus/cosmos-sdk v0.46.13-settlus.3
+	github.com/cosmos/cosmos-sdk => github.com/settlus/cosmos-sdk v0.46.13-settlus.4
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.7
 	// use cosmos flavored protobufs

--- a/go.sum
+++ b/go.sum
@@ -1210,8 +1210,8 @@ github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KR
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/settlus/cosmos-sdk v0.46.13-settlus.3 h1:JTVeKlxdD42sU58UHRrhOi1m/WKirny0aEjS5q2G568=
-github.com/settlus/cosmos-sdk v0.46.13-settlus.3/go.mod h1:EfY521ATNEla8eJ6oJuZBdgP5+p360s7InnRqX+TWdM=
+github.com/settlus/cosmos-sdk v0.46.13-settlus.4 h1:x4+rqa9DlVTeQgAgmxVBFd5dGGnnIo2sGi+yujdrZdE=
+github.com/settlus/cosmos-sdk v0.46.13-settlus.4/go.mod h1:EfY521ATNEla8eJ6oJuZBdgP5+p360s7InnRqX+TWdM=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible h1:Bn1aCHHRnjv4Bl16T8rcaFjYSrGrIZvpiGO6P3Q4GpU=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=


### PR DESCRIPTION
- bump settlus/cosmos-sdk from 3 to 4
  - allow probono validator delegation only through governance