### PR TITLE
feat(interop-node): use json rpc instead of go-ethereum client

### DIFF
--- a/evmos/x/erc20/types/erc20.pb.go
+++ b/evmos/x/erc20/types/erc20.pb.go
@@ -57,7 +57,8 @@ func (Owner) EnumDescriptor() ([]byte, []int) {
 }
 
 // TokenPair defines an instance that records a pairing consisting of a native
-//  Cosmos Coin and an ERC20 token address.
+//
+//	Cosmos Coin and an ERC20 token address.
 type TokenPair struct {
 	// erc20_address is the hex address of ERC20 contract token
 	Erc20Address string `protobuf:"bytes,1,opt,name=erc20_address,json=erc20Address,proto3" json:"erc20_address,omitempty"`


### PR DESCRIPTION
use json rpc instead of go-ethereum client for interop-node.