### PR TITLE
fix: do not close already closed channel

### DIFF
--- a/tools/interop-node/subscriber/ethereum_subscriber.go
+++ b/tools/interop-node/subscriber/ethereum_subscriber.go
@@ -235,11 +235,9 @@ func (sub *EthereumSubscriber) fetchLoop(ctx context.Context) {
 			sub.dbCh <- event
 		case <-ctx.Done():
 			sub.logger.Info("fetchLoop stopped")
-			close(sub.dbCh)
 			return
 		}
 	}
-
 }
 
 // parseBlock parses the block and returns the block event data


### PR DESCRIPTION
do not close already closed `sub.dbCh` in `fetchLoop()`. It is already closed in  `dbLoop()`. 

https://github.com/settlus/chain/blob/324e62eb39dcd7b52d002404937149eb828b3a0a/tools/interop-node/subscriber/ethereum_subscriber.go#L206