### PR TITLE
feat: add version cli for interop-node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ ldflags := -X github.com/cosmos/cosmos-sdk/version.Name=settlus \
            -X github.com/cosmos/cosmos-sdk/version.AppName=$(SETTLUS_BINARY) \
            -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
            -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
+           -X github.com/settlus/chain/tools/interop-node/version.Name=interop-node \
+           -X github.com/settlus/chain/tools/interop-node/version.Version=$(VERSION) \
+           -X github.com/settlus/chain/tools/interop-node/version.Commit=$(COMMIT)
 
 # Build tags to linker flags
 build_tags_comma_sep := $(subst $(subst ,, ),,,$(build_tags))

--- a/tools/interop-node/cmd/root.go
+++ b/tools/interop-node/cmd/root.go
@@ -23,6 +23,7 @@ func rootCmd() *cobra.Command {
 
 	cmd.AddCommand(configCmd())
 	cmd.AddCommand(startCmd())
+	cmd.AddCommand(VersionCommand())
 
 	return cmd
 }

--- a/tools/interop-node/cmd/version.go
+++ b/tools/interop-node/cmd/version.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	"github.com/settlus/chain/tools/interop-node/version"
+)
+
+const (
+	flagLong   = "long"
+	flagOutput = "output"
+)
+
+// VersionCommand returns a CLI command to interactively print the application binary version information.
+// Note: When seeking to add the extra info to the context
+// The below can be added to the initRootCmd to include the extraInfo field
+//
+// cmdContext := context.WithValue(context.Background(), version.ContextKey{}, extraInfo)
+// rootCmd.SetContext(cmdContext)
+func VersionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the application binary version information",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			verInfo := version.NewInfo()
+
+			s, _ := json.MarshalIndent(verInfo, "", "\t")
+			fmt.Print(string(s))
+
+			if long, _ := cmd.Flags().GetBool(flagLong); !long {
+				fmt.Fprintln(cmd.OutOrStdout(), verInfo.Version)
+				return nil
+			}
+
+			// Extract and set extra information from the context
+			verInfo.ExtraInfo = extraInfoFromContext(cmd)
+
+			var (
+				bz  []byte
+				err error
+			)
+
+			output, _ := cmd.Flags().GetString(flagOutput)
+			switch strings.ToLower(output) {
+			case "json":
+				bz, err = json.Marshal(verInfo)
+
+			default:
+				bz, err = yaml.Marshal(&verInfo)
+			}
+
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), string(bz))
+			return nil
+		},
+	}
+
+	cmd.Flags().Bool(flagLong, false, "Print long version information")
+	cmd.Flags().StringP(flagOutput, "o", "text", "Output format (text|json)")
+
+	return cmd
+}
+
+func extraInfoFromContext(cmd *cobra.Command) version.ExtraInfo {
+	ctx := cmd.Context()
+	if ctx != nil {
+		extraInfo, ok := ctx.Value(version.ContextKey{}).(version.ExtraInfo)
+		if ok {
+			return extraInfo
+		}
+	}
+	return nil
+}

--- a/tools/interop-node/version/version.go
+++ b/tools/interop-node/version/version.go
@@ -1,0 +1,126 @@
+// Package version is a convenience utility that provides SDK
+// consumers with a ready-to-use version command that
+// produces apps versioning information based on flags
+// passed at compile time.
+//
+// # Configure the version command
+//
+// The version command can be just added to your cobra root command.
+// At build time, the variables Name, Version, Commit, and BuildTags
+// can be passed as build flags as shown in the following example:
+//
+//	go build -X github.com/cosmos/cosmos-sdk/version.Name=gaia \
+//	 -X github.com/cosmos/cosmos-sdk/version.AppName=gaiad \
+//	 -X github.com/cosmos/cosmos-sdk/version.Version=1.0 \
+//	 -X github.com/cosmos/cosmos-sdk/version.Commit=f0f7b7dab7e36c20b757cebce0e8f4fc5b95de60 \
+//	 -X "github.com/cosmos/cosmos-sdk/version.BuildTags=linux darwin amd64"
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+)
+
+// ContextKey is used to store the ExtraInfo in the context.
+type ContextKey struct{}
+
+var (
+	// Name application's name
+	Name = ""
+	// AppName application binary name
+	AppName = "<appd>"
+	// Version application's version string
+	Version = ""
+	// Commit commit
+	Commit = ""
+	// BuildTags build tags
+	BuildTags = ""
+)
+
+func getSDKVersion() string {
+	deps, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unable to read deps"
+	}
+	var sdkVersion string
+	for _, dep := range deps.Deps {
+		if dep.Path == "github.com/cosmos/cosmos-sdk" {
+			if dep.Replace != nil && dep.Replace.Version != "(devel)" {
+				sdkVersion = dep.Replace.Version
+			} else {
+				sdkVersion = dep.Version
+			}
+		}
+	}
+
+	return sdkVersion
+}
+
+// ExtraInfo contains a set of extra information provided by apps
+type ExtraInfo map[string]string
+
+// Info defines the application version information.
+type Info struct {
+	Name             string     `json:"name" yaml:"name"`
+	AppName          string     `json:"server_name" yaml:"server_name"`
+	Version          string     `json:"version" yaml:"version"`
+	GitCommit        string     `json:"commit" yaml:"commit"`
+	BuildTags        string     `json:"build_tags" yaml:"build_tags"`
+	GoVersion        string     `json:"go" yaml:"go"`
+	BuildDeps        []buildDep `json:"build_deps" yaml:"build_deps"`
+	CosmosSdkVersion string     `json:"cosmos_sdk_version" yaml:"cosmos_sdk_version"`
+	ExtraInfo        ExtraInfo  `json:"extra_info,omitempty" yaml:"extra_info,omitempty"`
+}
+
+func NewInfo() Info {
+	sdkVersion := getSDKVersion()
+	return Info{
+		Name:             Name,
+		AppName:          AppName,
+		Version:          Version,
+		GitCommit:        Commit,
+		BuildTags:        BuildTags,
+		GoVersion:        fmt.Sprintf("go version %s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+		BuildDeps:        depsFromBuildInfo(),
+		CosmosSdkVersion: sdkVersion,
+	}
+}
+
+func (vi Info) String() string {
+	return fmt.Sprintf(`%s: %s
+git commit: %s
+build tags: %s
+%s`,
+		vi.Name, vi.Version, vi.GitCommit, vi.BuildTags, vi.GoVersion,
+	)
+}
+
+func depsFromBuildInfo() (deps []buildDep) {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+
+	for _, dep := range buildInfo.Deps {
+		deps = append(deps, buildDep{dep})
+	}
+
+	return
+}
+
+type buildDep struct {
+	*debug.Module
+}
+
+func (d buildDep) String() string {
+	if d.Replace != nil {
+		return fmt.Sprintf("%s@%s => %s@%s", d.Path, d.Version, d.Replace.Path, d.Replace.Version)
+	}
+
+	return fmt.Sprintf("%s@%s", d.Path, d.Version)
+}
+
+func (d buildDep) MarshalJSON() ([]byte, error)      { return json.Marshal(d.String()) }
+func (d buildDep) MarshalYAML() (interface{}, error) { return d.String(), nil }

--- a/tools/interop-node/version/version.go
+++ b/tools/interop-node/version/version.go
@@ -1,4 +1,4 @@
-// Package version is a convenience utility that provides SDK
+// Package version is a convenience utility that provides interop-node
 // consumers with a ready-to-use version command that
 // produces apps versioning information based on flags
 // passed at compile time.
@@ -9,11 +9,11 @@
 // At build time, the variables Name, Version, Commit, and BuildTags
 // can be passed as build flags as shown in the following example:
 //
-//	go build -X github.com/cosmos/cosmos-sdk/version.Name=gaia \
-//	 -X github.com/cosmos/cosmos-sdk/version.AppName=gaiad \
-//	 -X github.com/cosmos/cosmos-sdk/version.Version=1.0 \
-//	 -X github.com/cosmos/cosmos-sdk/version.Commit=f0f7b7dab7e36c20b757cebce0e8f4fc5b95de60 \
-//	 -X "github.com/cosmos/cosmos-sdk/version.BuildTags=linux darwin amd64"
+//	go build -X github.com/settlus/chain/tools/interop-node/version.Name=gaia \
+//	 -X github.com/settlus/chain/tools/interop-node/version.AppName=gaiad \
+//	 -X github.com/settlus/chain/tools/interop-node/version.Version=1.0 \
+//	 -X github.com/settlus/chain/tools/interop-node/version.Commit=f0f7b7dab7e36c20b757cebce0e8f4fc5b95de60 \
+//	 -X "github.com/settlus/chain/tools/interop-node/version.BuildTags=linux darwin amd64"
 package version
 
 import (
@@ -39,52 +39,30 @@ var (
 	BuildTags = ""
 )
 
-func getSDKVersion() string {
-	deps, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "unable to read deps"
-	}
-	var sdkVersion string
-	for _, dep := range deps.Deps {
-		if dep.Path == "github.com/cosmos/cosmos-sdk" {
-			if dep.Replace != nil && dep.Replace.Version != "(devel)" {
-				sdkVersion = dep.Replace.Version
-			} else {
-				sdkVersion = dep.Version
-			}
-		}
-	}
-
-	return sdkVersion
-}
-
 // ExtraInfo contains a set of extra information provided by apps
 type ExtraInfo map[string]string
 
 // Info defines the application version information.
 type Info struct {
-	Name             string     `json:"name" yaml:"name"`
-	AppName          string     `json:"server_name" yaml:"server_name"`
-	Version          string     `json:"version" yaml:"version"`
-	GitCommit        string     `json:"commit" yaml:"commit"`
-	BuildTags        string     `json:"build_tags" yaml:"build_tags"`
-	GoVersion        string     `json:"go" yaml:"go"`
-	BuildDeps        []buildDep `json:"build_deps" yaml:"build_deps"`
-	CosmosSdkVersion string     `json:"cosmos_sdk_version" yaml:"cosmos_sdk_version"`
-	ExtraInfo        ExtraInfo  `json:"extra_info,omitempty" yaml:"extra_info,omitempty"`
+	Name      string     `json:"name" yaml:"name"`
+	AppName   string     `json:"server_name" yaml:"server_name"`
+	Version   string     `json:"version" yaml:"version"`
+	GitCommit string     `json:"commit" yaml:"commit"`
+	BuildTags string     `json:"build_tags" yaml:"build_tags"`
+	GoVersion string     `json:"go" yaml:"go"`
+	BuildDeps []buildDep `json:"build_deps" yaml:"build_deps"`
+	ExtraInfo ExtraInfo  `json:"extra_info,omitempty" yaml:"extra_info,omitempty"`
 }
 
 func NewInfo() Info {
-	sdkVersion := getSDKVersion()
 	return Info{
-		Name:             Name,
-		AppName:          AppName,
-		Version:          Version,
-		GitCommit:        Commit,
-		BuildTags:        BuildTags,
-		GoVersion:        fmt.Sprintf("go version %s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
-		BuildDeps:        depsFromBuildInfo(),
-		CosmosSdkVersion: sdkVersion,
+		Name:      Name,
+		AppName:   AppName,
+		Version:   Version,
+		GitCommit: Commit,
+		BuildTags: BuildTags,
+		GoVersion: fmt.Sprintf("go version %s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+		BuildDeps: depsFromBuildInfo(),
 	}
 }
 


### PR DESCRIPTION
## PR Description
So far, it was hard to tell the current version of the `interop-node` node binary. Wit this new `version` CLI, we can easily tell its version.

## Changes
- updated Makefile to have build flags for interop-node.
- added `github.com/settlus/chain/tools/interop-node/version` package.