### PR TITLE
fix(interop-node): fix eth block hash mismatch in interop-node

### DIFF
--- a/tools/interop-node/subscriber/ethereum_subscriber.go
+++ b/tools/interop-node/subscriber/ethereum_subscriber.go
@@ -207,7 +207,7 @@ func (sub *EthereumSubscriber) fetchLoop(ctx context.Context) {
 				sub.logger.Error(err.Error(), "from", "latest block")
 				continue
 			}
-			blockHash, blockTime, err := sub.getBlockHash(blockNumber)
+			blockHash, blockTime, err := sub.getBlockByNumber(blockNumber)
 			if err != nil {
 				sub.logger.Error(err.Error(), "from", "block fetch", "hash", blockHash)
 				continue
@@ -234,7 +234,7 @@ func (sub *EthereumSubscriber) parseBlock(blockNumber *big.Int, blockHash string
 	}
 
 	return &types.BlockEventData{
-		BlockNumber:    big.NewInt(1),
+		BlockNumber:    blockNumber,
 		BlockHash:      []byte(blockHash),
 		Timestamp:      blockTime,
 		NftTransferred: erc721Transferred,
@@ -400,8 +400,8 @@ func toBlockNumArg(number *big.Int) string {
 	return hexutil.EncodeBig(number)
 }
 
-// getBlockHash returns the block by number
-func (sub *EthereumSubscriber) getBlockHash(blockNumber *big.Int) (string, uint64, error) {
+// getBlockByNumber returns the block by number
+func (sub *EthereumSubscriber) getBlockByNumber(blockNumber *big.Int) (string, uint64, error) {
 	body, err := json.Marshal(types.EthRpcInput{
 		JsonRpc: "2.0",
 		Method:  "eth_getBlockByNumber",

--- a/tools/interop-node/types/ethereum.go
+++ b/tools/interop-node/types/ethereum.go
@@ -1,0 +1,55 @@
+package types
+
+import ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+// Header represents a block header in the Ethereum blockchain.
+type Header struct {
+	Hash      string `json:"hash"`
+	Number    string `json:"number"`
+	Timestamp string `json:"timestamp"`
+}
+
+// BlockByNumberOutput is a JSON-RPC response containing a block header.
+// if an error occurred, the error field will be non-nil.
+type BlockByNumberOutput struct {
+	Jsonrpc string  `json:"jsonrpc"`
+	Id      string  `json:"id"`
+	Result  *Header `json:"result"`
+	Error   *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// BlockByHashOutput is a JSON-RPC response containing a block header.
+type BlockByHashOutput struct {
+	Jsonrpc string  `json:"jsonrpc"`
+	Id      int     `json:"id"`
+	Result  *Header `json:"result"`
+}
+
+// BlockNumberOutput is a JSON-RPC response containing the current block number.
+type BlockNumberOutput struct {
+	Jsonrpc string `json:"jsonrpc"`
+	Id      int    `json:"id"`
+	Result  string `json:"result"`
+}
+
+type EthRpcInput struct {
+	JsonRpc string        `json:"jsonrpc"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+	Id      string        `json:"id"`
+}
+
+type OwnerOfOutput struct {
+	JsonRpc string `json:"jsonrpc"`
+	Id      int    `json:"id"`
+	Result  string `json:"result"`
+}
+
+type FilterLogOutput struct {
+	Jsonrpc string         `json:"jsonrpc"`
+	Id      string         `json:"id"`
+	Result  []ethtypes.Log `json:"result"`
+}


### PR DESCRIPTION
## PR Description
Our current geth version derives block hash via hashing the block header. This is results in a block hash mismatch because the current Ethereum mainnet has new fields like `blobGasUsed` and `excessBlobGas` in the block header. This PR address the issue by directly using the block hash returned via JSON-RPC.

## Changes
- move ethereum RPC output structs to `types/ethereum.go`.
- manually decode block timestamp with `hexutil`.
- `getBlockHash()` returns blockHash (string) and blockTime (uint64) instead of `Block` object