### PR TITLE
fix: move settlement process from beginblock to endblock

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -711,8 +711,8 @@ func New(
 		erc20types.ModuleName,
 
 		// Settlus modules
-		settlementmoduletypes.ModuleName,
 		oraclemoduletypes.ModuleName,
+		settlementmoduletypes.ModuleName,
 	)
 
 	// NOTE: The genutils module must occur after staking so that pools are

--- a/x/settlement/abci.go
+++ b/x/settlement/abci.go
@@ -10,7 +10,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func BeginBlocker(ctx sdk.Context, k *keeper.SettlementKeeper) {
+func EndBlock(ctx sdk.Context, k *keeper.SettlementKeeper) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), "begin_blocker")
 
 	for _, tenant := range k.GetAllTenants(ctx) {

--- a/x/settlement/module.go
+++ b/x/settlement/module.go
@@ -154,10 +154,10 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
-	BeginBlocker(ctx, am.keeper)
 }
 
 // EndBlock contains the logic that is automatically triggered at the end of each block
-func (am AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	EndBlock(ctx, am.keeper)
 	return []abci.ValidatorUpdate{}
 }


### PR DESCRIPTION
To mitigate the scenario where the oracle's end vote height is the same as the settlement payout block height