### PR TITLE
fix: normalize hexaddrstring for consistency

### DIFF
--- a/tools/interop-node/subscriber/ethereum_subscriber.go
+++ b/tools/interop-node/subscriber/ethereum_subscriber.go
@@ -59,10 +59,6 @@ func (sub *EthereumSubscriber) Stop() {
 
 // OwnerOf returns the owner of the given NFT
 func (sub *EthereumSubscriber) OwnerOf(_ context.Context, nftAddressHex string, tokenIdHex string, blockHash string) (string, error) {
-	return sub.findOwnerFromNetwork(nftAddressHex, tokenIdHex, blockHash)
-}
-
-func (sub *EthereumSubscriber) findOwnerFromNetwork(nftAddressHex string, tokenIdHex string, blockHash string) (string, error) {
 	if !strings.HasPrefix(nftAddressHex, "0x") {
 		nftAddressHex = "0x" + nftAddressHex
 	}

--- a/types/hex_address.go
+++ b/types/hex_address.go
@@ -3,7 +3,6 @@ package types
 import (
 	"strings"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -11,8 +10,12 @@ const AccAddressByteSize = 20
 
 type HexAddressString string
 
-func NewHexAddrFromAccAddr(addr sdk.AccAddress) HexAddressString {
-	return HexAddressString(common.BytesToAddress(addr.Bytes()).Hex())
+func NewHexAddrFromBytes(addr []byte) HexAddressString {
+	return HexAddressString(common.BytesToAddress(addr).Hex())
+}
+
+func NoramlizeHexAddress(addr string) HexAddressString {
+	return HexAddressString(common.HexToAddress(addr).Hex())
 }
 
 func (a HexAddressString) Marshal() ([]byte, error) {

--- a/types/hex_address_test.go
+++ b/types/hex_address_test.go
@@ -26,7 +26,7 @@ func Test_NewHexAddressString(t *testing.T) {
 	for _, testCase := range testCases {
 		_, bytes, err := bech32.DecodeAndConvert(testCase.Bech32)
 		require.NoError(t, err)
-		address := types.NewHexAddrFromAccAddr(bytes)
+		address := types.NewHexAddrFromBytes(bytes)
 		require.Equal(t, testCase.Hex, address.String())
 	}
 }

--- a/types/nft.go
+++ b/types/nft.go
@@ -14,8 +14,8 @@ func ParseNftId(nftId string) (Nft, error) {
 
 	return Nft{
 		ChainId:      data[0],
-		ContractAddr: HexAddressString(data[1]),
-		TokenId:      HexAddressString(data[2]),
+		ContractAddr: NoramlizeHexAddress(data[1]),
+		TokenId:      NoramlizeHexAddress(data[2]),
 	}, nil
 }
 

--- a/x/oracle/types/vote_data.go
+++ b/x/oracle/types/vote_data.go
@@ -88,7 +88,7 @@ func StringToOwnershipData(voteString string) (ctypes.Nft, ctypes.HexAddressStri
 		return ctypes.Nft{}, "", fmt.Errorf("invalid nftId: %s", data[0])
 	}
 
-	owner := ctypes.HexAddressString(data[1])
+	owner := ctypes.NoramlizeHexAddress(data[1])
 
 	return nft, owner, err
 }

--- a/x/oracle/types/vote_data_test.go
+++ b/x/oracle/types/vote_data_test.go
@@ -78,10 +78,10 @@ func TestStringToOwnershipData(t *testing.T) {
 			expected: Result{
 				nft: ctypes.Nft{
 					ChainId:      "1",
-					ContractAddr: "0x123",
-					TokenId:      "0x0",
+					ContractAddr: ctypes.NoramlizeHexAddress("0x123"),
+					TokenId:      ctypes.NoramlizeHexAddress("0x0"),
 				},
-				owner: ctypes.HexAddressString("0x777"),
+				owner: ctypes.NoramlizeHexAddress("0x777"),
 				err:   false,
 			},
 		},
@@ -91,10 +91,10 @@ func TestStringToOwnershipData(t *testing.T) {
 			expected: Result{
 				nft: ctypes.Nft{
 					ChainId:      "1",
-					ContractAddr: "123",
-					TokenId:      "0a",
+					ContractAddr: ctypes.NoramlizeHexAddress("0x123"),
+					TokenId:      ctypes.NoramlizeHexAddress("0xa"),
 				},
-				owner: ctypes.HexAddressString("777"),
+				owner: ctypes.NoramlizeHexAddress("777"),
 				err:   false,
 			},
 		},

--- a/x/oracle/voteprocessor/voteprocessor_test.go
+++ b/x/oracle/voteprocessor/voteprocessor_test.go
@@ -158,7 +158,8 @@ func TestOwnershipVoteProcessor(t *testing.T) {
 
 	vp.TallyVotes(ctx, validatorClaimMap)
 
-	require.Equal(t, ctypes.HexAddressString("0x777"), result["1/0x123/0x0"])
+	require.Equal(t, ctypes.HexAddressString("0x0000000000000000000000000000000000000777"),
+		result["1/0x0000000000000000000000000000000000000123/0x0000000000000000000000000000000000000000"])
 
 	require.False(t, validatorClaimMap[addrs[0].String()].Miss)
 	require.False(t, validatorClaimMap[addrs[1].String()].Miss)

--- a/x/settlement/keeper/keeper.go
+++ b/x/settlement/keeper/keeper.go
@@ -89,9 +89,10 @@ func (k SettlementKeeper) GetRecipients(ctx sdk.Context, chainId string, contrac
 		return nil, errorsmod.Wrapf(types.ErrEVMCallFailed, "failed to get the owner of the given NFT")
 	}
 
-	// TODO: suupport multi-owner
+	// TODO: support multi-owner
 	recipient := &types.Recipient{
-		Address: ctypes.HexAddressString(address.Hex()),
+		Address: ctypes.NewHexAddrFromBytes(address.Bytes()),
+		Weight:  1,
 	}
 
 	return append(recipients, recipient), nil

--- a/x/settlement/keeper/msg_server.go
+++ b/x/settlement/keeper/msg_server.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	ctypes "github.com/settlus/chain/types"
-	settlustypes "github.com/settlus/chain/types"
 	"github.com/settlus/chain/x/settlement/types"
 
 	errorsmod "cosmossdk.io/errors"
@@ -54,7 +53,8 @@ func (k msgServer) Record(goCtx context.Context, msg *types.MsgRecord) (*types.M
 	}
 
 	payoutBlock := uint64(ctx.BlockHeight())
-
+	contractAddr := ctypes.NoramlizeHexAddress(msg.ContractAddress)
+	tokenId := ctypes.NoramlizeHexAddress(msg.TokenIdHex)
 	utxrId, err := k.CreateUTXR(
 		ctx,
 		msg.TenantId,
@@ -64,8 +64,8 @@ func (k msgServer) Record(goCtx context.Context, msg *types.MsgRecord) (*types.M
 			Amount:     msg.Amount,
 			Nft: &ctypes.Nft{
 				ChainId:      msg.ChainId,
-				ContractAddr: settlustypes.HexAddressString(msg.ContractAddress),
-				TokenId:      settlustypes.HexAddressString(msg.TokenIdHex),
+				ContractAddr: contractAddr,
+				TokenId:      tokenId,
 			},
 			CreatedAt: payoutBlock,
 		},
@@ -82,8 +82,8 @@ func (k msgServer) Record(goCtx context.Context, msg *types.MsgRecord) (*types.M
 		Amount:    msg.Amount,
 		Nft: &ctypes.Nft{
 			ChainId:      msg.ChainId,
-			ContractAddr: settlustypes.HexAddressString(msg.ContractAddress),
-			TokenId:      settlustypes.HexAddressString(msg.TokenIdHex),
+			ContractAddr: contractAddr,
+			TokenId:      tokenId,
 		},
 		Recipients: recipients,
 		Metadata:   msg.Metadata,

--- a/x/settlement/keeper/utxr.go
+++ b/x/settlement/keeper/utxr.go
@@ -178,6 +178,7 @@ func (k SettlementKeeper) SetRecipients(ctx sdk.Context, nfts map[ctypes.Nft]cty
 			}
 			utxr.Recipients = []*types.Recipient{{
 				Address: owner,
+				Weight:  1,
 			}}
 			bz := k.cdc.MustMarshal(&utxr)
 			key := iterator.Key()

--- a/x/settlement/types/recipient.go
+++ b/x/settlement/types/recipient.go
@@ -8,7 +8,8 @@ import (
 func SingleRecipients(creator sdk.AccAddress) []*Recipient {
 	return []*Recipient{
 		{
-			Address: ctypes.NewHexAddrFromAccAddr(creator),
+			Address: ctypes.NewHexAddrFromBytes(creator),
+			Weight:  1,
 		},
 	}
 }


### PR DESCRIPTION
Currently, votes with data "0x0" and "0x000" are treated as different. To fix this, we need to normalize the hexaddrstring  to a consistent address length.