### PR TITLE
fix: use KVStore for storing curren round info

### DIFF
--- a/app/keepers.go
+++ b/app/keepers.go
@@ -343,7 +343,6 @@ func NewAppKeeper(
 	appKeepers.OracleKeeper = oraclemodulekeeper.NewKeeper(
 		appCodec,
 		appKeepers.keys[oraclemoduletypes.StoreKey],
-		appKeepers.tkeys[oraclemoduletypes.TransientKey],
 		appKeepers.GetSubspace(oraclemoduletypes.ModuleName),
 		appKeepers.AccountKeeper,
 		appKeepers.BankKeeper,

--- a/app/keys.go
+++ b/app/keys.go
@@ -67,7 +67,7 @@ func (appKeepers *AppKeepers) GenerateKeys() {
 
 	// Define transient store keys
 	appKeepers.tkeys = sdk.NewTransientStoreKeys(
-		paramstypes.TStoreKey, evmtypes.TransientKey, feemarkettypes.TransientKey, oraclemoduletypes.TransientKey,
+		paramstypes.TStoreKey, evmtypes.TransientKey, feemarkettypes.TransientKey,
 	)
 
 	// MemKeys are for information that is stored only in RAM.

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -29,8 +29,6 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 		return
 	}
 
-	logger := k.Logger(ctx)
-
 	maxValidators := k.StakingKeeper.MaxValidators(ctx)
 	iterator := k.StakingKeeper.ValidatorsPowerStoreIterator(ctx)
 	defer iterator.Close()
@@ -89,6 +87,7 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 
 	// distribute rewards to winners
 	if err := k.RewardBallotWinners(ctx, validatorClaimMap); err != nil {
+		logger := k.Logger(ctx)
 		logger.Error("failed to distribute rewards", "error", err)
 	}
 

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -18,10 +18,9 @@ const BlockTimestampMargin = 15 * time.Second
 
 type (
 	Keeper struct {
-		cdc          codec.BinaryCodec
-		storeKey     storetypes.StoreKey
-		transientKey storetypes.StoreKey
-		paramstore   paramtypes.Subspace
+		cdc        codec.BinaryCodec
+		storeKey   storetypes.StoreKey
+		paramstore paramtypes.Subspace
 
 		AccountKeeper      types.AccountKeeper
 		BankKeeper         types.BankKeeper
@@ -35,7 +34,7 @@ type (
 
 func NewKeeper(
 	cdc codec.BinaryCodec,
-	storeKey, transientKey storetypes.StoreKey,
+	storeKey storetypes.StoreKey,
 	ps paramtypes.Subspace,
 
 	accountKeeper types.AccountKeeper,
@@ -57,10 +56,9 @@ func NewKeeper(
 	}
 
 	return &Keeper{
-		cdc:          cdc,
-		storeKey:     storeKey,
-		transientKey: transientKey,
-		paramstore:   ps,
+		cdc:        cdc,
+		storeKey:   storeKey,
+		paramstore: ps,
 
 		AccountKeeper:      accountKeeper,
 		BankKeeper:         bankKeeper,
@@ -77,8 +75,8 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 }
 
 func (k Keeper) GetCurrentRoundInfo(ctx sdk.Context) *types.RoundInfo {
-	store := ctx.TransientStore(k.transientKey)
-	bz := store.Get(types.CurrentRoundBytesTransientKeyPrefix)
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.RoundKeyPrefix)
 	if len(bz) == 0 {
 		return nil
 	}
@@ -89,9 +87,9 @@ func (k Keeper) GetCurrentRoundInfo(ctx sdk.Context) *types.RoundInfo {
 }
 
 func (k Keeper) SetCurrentRoundInfo(ctx sdk.Context, roundInfo *types.RoundInfo) {
-	store := ctx.TransientStore(k.transientKey)
+	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(roundInfo)
-	store.Set(types.CurrentRoundBytesTransientKeyPrefix, bz)
+	store.Set(types.RoundKeyPrefix, bz)
 }
 
 func (k Keeper) CalculateCurrentRoundInfo(ctx sdk.Context) *types.RoundInfo {

--- a/x/oracle/types/keys.go
+++ b/x/oracle/types/keys.go
@@ -9,10 +9,6 @@ const (
 
 	// RouterKey defines the module's message routing key
 	RouterKey = ModuleName
-
-	// TransientKey is the key to access the Oracle transient store, that is reset
-	// during the Commit phase.
-	TransientKey = "transient_" + ModuleName
 )
 
 var (
@@ -22,8 +18,6 @@ var (
 	AggregatePrevoteKeyPrefix = []byte{0x03}
 	AggregateVoteKeyPrefix    = []byte{0x04}
 	RoundKeyPrefix            = []byte{0x05}
-
-	CurrentRoundBytesTransientKeyPrefix = []byte{0x00}
 )
 
 func KeyPrefix(p string) []byte {


### PR DESCRIPTION
TransientStore was not successful for storing current round info.  
KVStore should be the valid option.