### PR TITLE
test: fix e2e tests

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,7 @@ accounts:
   - name: faucet
     coins:
       - 10000000000000000000000000asetl
+      - 10000000000000000000000000uusdc
     mnemonic: island club point history solution tonight festival maid zebra business nasty clap spirit science excess win caution hand embrace heavy snow derive nuclear head
 client:
   typescript:

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spf13/cast v1.6.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.18.2
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.9.1-0.20240613200951-b074924938f8
 	go.opencensus.io v0.24.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240723171418-e6d459c13d2a
 	google.golang.org/grpc v1.65.0

--- a/go.sum
+++ b/go.sum
@@ -1278,8 +1278,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.9.1-0.20240613200951-b074924938f8 h1:lMSOB3NNaQcNDK9eCjQb0LFfpXW03lzF2SN6vUziALo=
+github.com/stretchr/testify v1.9.1-0.20240613200951-b074924938f8/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=

--- a/tests/e2e/e2e_bank_test.go
+++ b/tests/e2e/e2e_bank_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"crypto/rand"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -9,20 +10,15 @@ import (
 func (s *IntegrationTestSuite) TestBankTokenTransfer() {
 	s.Run("send_setl_between_accounts", func() {
 		var err error
-		sender := treasuryAddr
-		recipient := "settlus10z74aw2m660tuezej4w5zr35zye6684t5ejjmk"
+		sender := bobAddr
+		recipient := makeRandomAccAddress()
 
-		var (
-			beforeSenderASetlBalance    sdk.Coin
-			beforeRecipientASetlBalance sdk.Coin
-		)
+		var beforeSenderASetlBalance sdk.Coin
+		beforeRecipientASetlBalance := sdk.NewCoin(asetlDenom, sdk.NewInt(0))
 
 		s.Require().Eventually(
 			func() bool {
 				beforeSenderASetlBalance, err = getSpecificBalance(chainAPIEndpoint, sender, asetlDenom)
-				s.Require().NoError(err)
-
-				beforeRecipientASetlBalance, err = getSpecificBalance(chainAPIEndpoint, recipient, asetlDenom)
 				s.Require().NoError(err)
 
 				return true
@@ -51,4 +47,10 @@ func (s *IntegrationTestSuite) TestBankTokenTransfer() {
 			2*time.Second,
 		)
 	})
+}
+
+func makeRandomAccAddress() string {
+	recipientBytes := make([]byte, 20)
+	_, _ = rand.Read(recipientBytes)
+	return sdk.AccAddress(recipientBytes).String()
 }

--- a/tests/e2e/e2e_exec_test.go
+++ b/tests/e2e/e2e_exec_test.go
@@ -216,7 +216,6 @@ func (s *IntegrationTestSuite) execRecord(
 		settlusCmd = append(settlusCmd, fmt.Sprintf("--%s=%v", flag, value))
 	}
 
-	fmt.Println(settlusCmd)
 	s.executeSettlusTxCommand(ctx, settlusCmd)
 }
 

--- a/tests/e2e/e2e_settlement_test.go
+++ b/tests/e2e/e2e_settlement_test.go
@@ -211,29 +211,29 @@ func (s *IntegrationTestSuite) TestMintableContractTenant() {
 	})
 	s.Require().True(pass)
 
-	//pass = s.Run("record_internal_nft_revenue", func() {
-	//	requestId := NewReqId()
-	//	s.execRecord(s.admin, tenantId, requestId, revenue.String(), chainId, s.internalNftAddr, internalNftId)
-	//
-	//	utxr, err := queryUtxr(chainAPIEndpoint, tenantId, requestId)
-	//	s.Require().NoError(err)
-	//	s.Require().Equal(common.FromHex(internalNftOwner), utxr.Recipients[0].Address.Bytes())
-	//	s.Require().Equal(revenue, utxr.Amount)
-	//
-	//	beforeBalance, err := queryERC20Balance(s.ethClient, tenantContractAddr, internalNftOwner)
-	//	s.Require().NoError(err)
-	//
-	//	s.Require().Eventually(
-	//		func() bool {
-	//			afterBalance, err := queryERC20Balance(s.ethClient, tenantContractAddr, internalNftOwner)
-	//			s.Require().NoError(err)
-	//			return afterBalance-beforeBalance == revenue.Amount.Uint64()
-	//		},
-	//		time.Minute,
-	//		2*time.Second,
-	//	)
-	//})
-	//s.Require().True(pass)
+	pass = s.Run("record_internal_nft_revenue", func() {
+		requestId := NewReqId()
+		s.execRecord(s.admin, tenantId, requestId, revenue.String(), chainId, s.internalNftAddr, internalNftId)
+
+		utxr, err := queryUtxr(chainAPIEndpoint, tenantId, requestId)
+		s.Require().NoError(err)
+		s.Require().Equal(common.FromHex(internalNftOwner), utxr.Recipients[0].Address.Bytes())
+		s.Require().Equal(revenue, utxr.Amount)
+
+		beforeBalance, err := queryERC20Balance(s.ethClient, tenantContractAddr, internalNftOwner)
+		s.Require().NoError(err)
+
+		s.Require().Eventually(
+			func() bool {
+				afterBalance, err := queryERC20Balance(s.ethClient, tenantContractAddr, internalNftOwner)
+				s.Require().NoError(err)
+				return afterBalance-beforeBalance == revenue.Amount.Uint64()
+			},
+			time.Minute,
+			2*time.Second,
+		)
+	})
+	s.Require().True(pass)
 
 	pass = s.Run("record_external_nft_revenue", func() {
 		beforeBalance, err := queryERC20Balance(s.ethClient, tenantContractAddr, extNftOwner)

--- a/tests/e2e/e2e_settlement_test.go
+++ b/tests/e2e/e2e_settlement_test.go
@@ -30,7 +30,7 @@ func (s *IntegrationTestSuite) SetupSettlementTestSuite() {
 	admin := "admin" + strconv.Itoa(rand.Intn(10000000000))
 	s.admin = s.execKeyAdd(admin)
 	initialAmount := fmt.Sprintf("%d%s,%d%s", 10000000000000, asetlDenom, 10000000000000, uusdcDenom)
-	s.execBankSend(treasuryAddr, s.admin, initialAmount, standardFees.String())
+	s.execBankSend(faucetAddr, s.admin, initialAmount, standardFees.String())
 	s.Require().EventuallyWithT(
 		func(c *assert.CollectT) {
 			balance, err := getSpecificBalance(chainAPIEndpoint, s.admin, asetlDenom)
@@ -192,14 +192,14 @@ func (s *IntegrationTestSuite) TestMintableContractTenant() {
 		s.Require().EventuallyWithT(
 			func(c *assert.CollectT) {
 				afterTenants, err := queryTenants(chainAPIEndpoint)
-				s.Require().NoError(err)
-				s.Require().Equal(len(beforeTenants)+1, len(afterTenants))
+				require.NoError(c, err)
+				require.Equal(c, len(beforeTenants)+1, len(afterTenants))
 
 				newTenant := afterTenants[len(afterTenants)-1]
-				s.Require().Equal(denom, newTenant.Tenant.Denom)
-				s.Require().Equal(period, int(newTenant.Tenant.PayoutPeriod))
-				s.Require().Equal(types.PayoutMethod_MintContract, newTenant.Tenant.PayoutMethod)
-				s.Require().NotEmpty(newTenant.Tenant.ContractAddress)
+				require.Equal(c, denom, newTenant.Tenant.Denom)
+				require.Equal(c, period, int(newTenant.Tenant.PayoutPeriod))
+				require.Equal(c, types.PayoutMethod_MintContract, newTenant.Tenant.PayoutMethod)
+				require.NotEmpty(c, newTenant.Tenant.ContractAddress)
 
 				tenantId = newTenant.Tenant.Id
 				tenantContractAddr = newTenant.Tenant.ContractAddress
@@ -215,10 +215,18 @@ func (s *IntegrationTestSuite) TestMintableContractTenant() {
 		requestId := NewReqId()
 		s.execRecord(s.admin, tenantId, requestId, revenue.String(), chainId, s.internalNftAddr, internalNftId)
 
-		utxr, err := queryUtxr(chainAPIEndpoint, tenantId, requestId)
-		s.Require().NoError(err)
-		s.Require().Equal(common.FromHex(internalNftOwner), utxr.Recipients[0].Address.Bytes())
-		s.Require().Equal(revenue, utxr.Amount)
+		s.Require().EventuallyWithT(
+			func(c *assert.CollectT) {
+				utxr, err := queryUtxr(chainAPIEndpoint, tenantId, requestId)
+				require.NoError(c, err)
+				require.Equal(c, 1, len(utxr.Recipients))
+				require.Equal(c, common.FromHex(internalNftOwner), utxr.Recipients[0].Address.Bytes())
+				require.Equal(c, revenue, utxr.Amount)
+			},
+			10*time.Second,
+			time.Second,
+			"failed to query UTXR after recording internal NFT revenue",
+		)
 
 		beforeBalance, err := queryERC20Balance(s.ethClient, tenantContractAddr, internalNftOwner)
 		s.Require().NoError(err)
@@ -245,11 +253,11 @@ func (s *IntegrationTestSuite) TestMintableContractTenant() {
 		s.Require().EventuallyWithT(
 			func(c *assert.CollectT) {
 				utxr, err := queryUtxr(chainAPIEndpoint, tenantId, requestId)
-				s.Require().NoError(err)
-				s.Require().Equal(revenue, utxr.Amount)
+				require.NoError(c, err)
+				require.Equal(c, revenue, utxr.Amount)
 
-				s.Require().Greater(len(utxr.Recipients), 0)
-				s.Require().Equal(common.FromHex(extNftOwner), utxr.Recipients[0].Address.Bytes())
+				require.Greater(c, len(utxr.Recipients), 0)
+				require.Equal(c, common.FromHex(extNftOwner), utxr.Recipients[0].Address.Bytes())
 			},
 			time.Minute,
 			time.Second,

--- a/tests/e2e/e2e_setup_test.go
+++ b/tests/e2e/e2e_setup_test.go
@@ -20,7 +20,8 @@ const (
 
 var (
 	standardFees = sdk.NewCoin(asetlDenom, sdk.NewInt(300000000000000))
-	treasuryAddr = "settlus12g8w5dr5jyncct8jwdxwsy2g9ktdrjjlcs5f0a"
+	faucetAddr   = "settlus10z74aw2m660tuezej4w5zr35zye6684t5ejjmk" // faucet address specified in the config.yml
+	bobAddr      = "settlus1vfhltz7wr4ca862xd0azjuap4tupwgyzk7qukp" // bob address specified in the config.yml
 )
 
 type IntegrationTestSuite struct {

--- a/tests/e2e/query.go
+++ b/tests/e2e/query.go
@@ -87,7 +87,7 @@ func queryUtxr(endpoint string, tenantId uint64, requestId string) (*settlementt
 
 	var utxrResp settlementtypes.QueryUTXRResponse
 	if err := cdc.UnmarshalJSON(body, &utxrResp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal JSON: %w, %v", err, body)
 	}
 
 	return &utxrResp.Utxr, nil
@@ -102,6 +102,10 @@ func querySettlusAllBalances(endpoint, addr string) (sdk.Coins, error) {
 	var balancesResp banktypes.QueryAllBalancesResponse
 	if err := cdc.UnmarshalJSON(body, &balancesResp); err != nil {
 		return nil, err
+	}
+
+	if balancesResp.Balances == nil || len(balancesResp.Balances) == 0 {
+		return nil, fmt.Errorf("balances are nil or empty for address %s", addr)
 	}
 
 	return balancesResp.Balances, nil

--- a/types/nft.go
+++ b/types/nft.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	fmt "fmt"
+	"fmt"
 	"strings"
 )
 


### PR DESCRIPTION
## PR Description

Fix e2e tests

We need to use a specific version of `stretchr/testify` to include this PR (https://github.com/stretchr/testify/pull/1481). Without it, `EventuallyWithT` does not work well with `require`.

`EventuallyWithT` is preferable to plain `Eventually` because it shows exactly which condition is not met. For example, `Eventually`'s error looks like this:
```shell
Error:      	Condition never satisfied
```
In contrast, `EventuallyWithT`'s error log is more informative:
```shell
e2e_settlement_test.go:199:
    	Error Trace:	/Users/jacob/work/chain/tests/e2e/e2e_settlement_test.go:199
    	            				/opt/homebrew/Cellar/go/1.22.5/libexec/src/runtime/asm_arm64.s:1222
    	Error:      	Not equal:
    	            	expected: 3
    	            	actual  : 2
    	Test:       	TestIntegrationTestSuite/TestMintableContractTenant/create_new_tenant
```