### PR TITLE
feat: bump go version to 1.22 in github worflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,16 +22,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
-      - name: Lint
-        uses: golangci/golangci-lint-action@v5.1.0
+      - uses: golangci/golangci-lint-action@v6.0.1
         with:
           version: latest
+          args: --timeout 10m
+          github-token: ${{ secrets.github_token }}
           # skip cache because of flaky behaviors
           skip-build-cache: true
           skip-pkg-cache: true
-
+        if: "env.GIT_DIFF"
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -39,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - name: Test
         run: make test
@@ -55,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.31.0
+      - uses: bufbuild/buf-setup-action@v1.34.0
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: "proto --verbose"
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.31.0
+      - uses: bufbuild/buf-setup-action@v1.34.0
       - uses: bufbuild/buf-breaking-action@v1
         with:
           input: "proto"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
           check-latest: true
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Description

bump go version to 1.22 in github worflows