### PR TITLE
oracle: fix round info bug

### DIFF
--- a/tools/interop-node/client/settlus.go
+++ b/tools/interop-node/client/settlus.go
@@ -207,7 +207,6 @@ func (sc *SettlusClient) GetLatestHeight(ctx context.Context) (int64, error) {
 	for retryCount := 0; retryCount < HeightRetryCount; retryCount++ {
 		latestBlockHeight, err := sc.latestHeight(ctx)
 		if err == nil {
-			sc.logger.Debug("GetLatestHeight", "blocknumber", latestBlockHeight)
 			return latestBlockHeight, nil
 		}
 

--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -11,15 +11,12 @@ import (
 	"github.com/settlus/chain/x/oracle/voteprocessor"
 )
 
-// BeginBlocker runs at the beginning of every block
-func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
-	roundInfo := k.CalculateCurrentRoundInfo(ctx)
-	k.SetCurrentRoundInfo(ctx, roundInfo)
-}
-
 // EndBlocker runs at the end of every block
 func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyEndBlocker)
+
+	roundInfo := k.CalculateNextRoundInfo(ctx)
+	k.SetCurrentRoundInfo(ctx, roundInfo)
 
 	params := k.GetParams(ctx)
 

--- a/x/oracle/keeper/integration_test.go
+++ b/x/oracle/keeper/integration_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Oracle module integration tests", Ordered, func() {
 		BeforeEach(func() {
 		})
 		It("Less than the threshold signs, block data consensus fails", func() {
-			oracle.BeginBlocker(s.ctx, *s.app.OracleKeeper)
+			oracle.EndBlocker(s.ctx, *s.app.OracleKeeper)
 
 			salt := "1"
 			validator := s.validators[0]
@@ -44,7 +44,7 @@ var _ = Describe("Oracle module integration tests", Ordered, func() {
 			Expect(bd).To(BeNil())
 		})
 		It("All validators sign same block data, block data consensus succeeds", func() {
-			oracle.BeginBlocker(s.ctx, *s.app.OracleKeeper)
+			oracle.EndBlocker(s.ctx, *s.app.OracleKeeper)
 
 			// All validators sign
 			for i, validator := range s.validators {
@@ -60,7 +60,7 @@ var _ = Describe("Oracle module integration tests", Ordered, func() {
 			Expect(*bd).To(Equal(types.BlockData{ChainId: "1", BlockNumber: 100, BlockHash: blockHash}))
 		})
 		It("Tie between two block data, block data consensus succeeds", func() {
-			oracle.BeginBlocker(s.ctx.WithBlockHeight(DefaultVotePeriod), *s.app.OracleKeeper)
+			oracle.EndBlocker(s.ctx.WithBlockHeight(DefaultVotePeriod-1), *s.app.OracleKeeper)
 
 			// Two validators sign block number 100
 			for i, validator := range s.validators[:2] {
@@ -82,7 +82,7 @@ var _ = Describe("Oracle module integration tests", Ordered, func() {
 			Expect(bd).To(BeNil())
 		})
 		It("Abstain validator's power is majority, block data consensus fails", func() {
-			oracle.BeginBlocker(s.ctx.WithBlockHeight(2), *s.app.OracleKeeper)
+			oracle.EndBlocker(s.ctx.WithBlockHeight(1), *s.app.OracleKeeper)
 
 			// One validator abstains
 			abstainValidator := s.validators[0]
@@ -105,7 +105,7 @@ var _ = Describe("Oracle module integration tests", Ordered, func() {
 
 	Context("Test oracle vote period", func() {
 		BeforeEach(func() {
-			oracle.BeginBlocker(s.ctx.WithBlockHeight(1), *s.app.OracleKeeper)
+			oracle.EndBlocker(s.ctx.WithBlockHeight(0), *s.app.OracleKeeper)
 
 			for i, validator := range s.validators {
 				salt := fmt.Sprintf("%d", i)
@@ -114,7 +114,7 @@ var _ = Describe("Oracle module integration tests", Ordered, func() {
 			oracle.EndBlocker(s.ctx.WithBlockHeight(1), *s.app.OracleKeeper)
 		})
 		It("Vote period is 10, prevote is submitted at block 1, vote is submitted at block 10, block data is updated at block 19", func() {
-			oracle.BeginBlocker(s.ctx.WithBlockHeight(DefaultVotePeriod), *s.app.OracleKeeper)
+			oracle.EndBlocker(s.ctx.WithBlockHeight(DefaultVotePeriod-1), *s.app.OracleKeeper)
 
 			for i, validator := range s.validators {
 				salt := fmt.Sprintf("%d", i)
@@ -129,7 +129,7 @@ var _ = Describe("Oracle module integration tests", Ordered, func() {
 			Expect(*bd).To(Equal(types.BlockData{ChainId: "1", BlockNumber: 100, BlockHash: blockHash}))
 		})
 		It("Vote period is 10, prevote is submitted at block 1, vote is submitted at block 11, block data is not updated at block 12", func() {
-			oracle.BeginBlocker(s.ctx.WithBlockHeight(DefaultVotePeriod+1), *s.app.OracleKeeper)
+			oracle.EndBlocker(s.ctx.WithBlockHeight(DefaultVotePeriod), *s.app.OracleKeeper)
 
 			for i, validator := range s.validators {
 				salt := fmt.Sprintf("%d", i)
@@ -150,7 +150,7 @@ var _ = Describe("Oracle module integration tests", Ordered, func() {
 			Expect(prevotes.AggregatePrevotes).To(BeNil())
 		})
 		It("Vote period is 10, send prevote at block 1 and another at block 2. Send vote at block 10. Block data is updated at block 19", func() {
-			oracle.BeginBlocker(s.ctx.WithBlockHeight(2), *s.app.OracleKeeper)
+			oracle.EndBlocker(s.ctx.WithBlockHeight(1), *s.app.OracleKeeper)
 
 			voteData := types.BlockDataToVoteData(&types.BlockData{ChainId: "1", BlockNumber: 101, BlockHash: blockHash})
 

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -92,9 +92,9 @@ func (k Keeper) SetCurrentRoundInfo(ctx sdk.Context, roundInfo *types.RoundInfo)
 	store.Set(types.RoundKeyPrefix, bz)
 }
 
-func (k Keeper) CalculateCurrentRoundInfo(ctx sdk.Context) *types.RoundInfo {
+func (k Keeper) CalculateNextRoundInfo(ctx sdk.Context) *types.RoundInfo {
 	params := k.GetParams(ctx)
-	blockHeight := ctx.BlockHeight()
+	blockHeight := ctx.BlockHeight() + 1
 	prevoteEnd, voteEnd := types.CalculateVotePeriod(blockHeight, params.VotePeriod)
 
 	oracleData := []*types.OracleData{}

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -152,7 +152,6 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
-	BeginBlocker(ctx, am.keeper)
 }
 
 // EndBlock contains the logic that is automatically triggered at the end of each block


### PR DESCRIPTION
The `interop-node` uses the next height to calculate roundInfo, whereas the chain node returns roundInfo for the current height. To resolve this conflict, update the roundInfo for the next height in the `EndBlocker`.