### PR TITLE
hotfix: bump evmos version to v19.0.0-settlus.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -255,7 +255,7 @@ replace (
 	// use Evmos geth fork
 	github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc4
 	// use Settlus flavored Evmos
-	github.com/evmos/evmos/v19 => github.com/settlus/evmos/v19 v19.0.0-settlus.4
+	github.com/evmos/evmos/v19 => github.com/settlus/evmos/v19 v19.0.0-settlus.5
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
 	// use cosmos flavored protobufs

--- a/go.sum
+++ b/go.sum
@@ -1215,8 +1215,8 @@ github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfP
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/settlus/cosmos-sdk v0.47.12-settlus.3 h1:RINSLTQes1z/7xOVXeeQetW6Iojrw0GtgBSRS3diLjw=
 github.com/settlus/cosmos-sdk v0.47.12-settlus.3/go.mod h1:ADjORYzUQqQv/FxDi0H0K5gW/rAk1CiDR3ZKsExfJV0=
-github.com/settlus/evmos/v19 v19.0.0-settlus.4 h1:0JD8VUGJ2ny4leCnkF/BpSZaNOOwaeQjdNrab5SLENY=
-github.com/settlus/evmos/v19 v19.0.0-settlus.4/go.mod h1:cH2IV7ZrZlp+2KfeExMvtlQe8sxOYt2cC4J3ZiiwJHU=
+github.com/settlus/evmos/v19 v19.0.0-settlus.5 h1:knxDga8dm3jOMsas9L5S/ikoMgovHZVxjjueL+2nE3k=
+github.com/settlus/evmos/v19 v19.0.0-settlus.5/go.mod h1:cH2IV7ZrZlp+2KfeExMvtlQe8sxOYt2cC4J3ZiiwJHU=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible h1:Bn1aCHHRnjv4Bl16T8rcaFjYSrGrIZvpiGO6P3Q4GpU=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=


### PR DESCRIPTION
- https://github.com/evmos/evmos/releases/tag/v19.1.0